### PR TITLE
[pwm] Add PWM modules to dim RGB LEDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+bin/
+build/
+lib/
+lib64
+pyvenv.cfg
+share/
+sw/build/

--- a/ibex_demo_system_core.core
+++ b/ibex_demo_system_core.core
@@ -14,6 +14,8 @@ filesets:
       - rtl/system/ibex_demo_system.sv
       - rtl/system/dm_top.sv
       - rtl/system/gpio.sv
+      - rtl/system/pwm.sv
+      - rtl/system/pwm_wrapper.sv
       - rtl/system/uart.sv
     file_type: systemVerilogSource
 

--- a/rtl/fpga/top_artya7.sv
+++ b/rtl/fpga/top_artya7.sv
@@ -5,25 +5,29 @@
 // This is the top level SystemVerilog file that connects the IO on the board to the Ibex Demo System.
 module top_artya7 (
   // These inputs are defined in data/pins_artya7.xdc
-  input               IO_CLK,
-  input               IO_RST_N,
-  output [3:0]        LED,
-  output [11:0]       RGB_LED,
-  output              UART_TX
+  input         IO_CLK,
+  input         IO_RST_N,
+  output [ 3:0] LED,
+  output [11:0] RGB_LED,
+  output        UART_TX
 );
-  parameter              SRAMInitFile = "";
+  parameter SRAMInitFile = "";
 
   logic clk_sys, rst_sys_n;
 
   // Instantiating the Ibex Demo System.
   ibex_demo_system #(
-    .GpoWidth(16),
+    .GpoWidth(4),
+    .PwmWidth(12),
     .SRAMInitFile(SRAMInitFile)
   ) u_ibex_demo_system (
+    //input
     .clk_sys_i(clk_sys),
     .rst_sys_ni(rst_sys_n),
 
-    .gp_o({LED, RGB_LED}),
+    //output
+    .gp_o(LED),
+    .pwm_o(RGB_LED),
     .uart_tx_o(UART_TX)
   );
 

--- a/rtl/system/dm_top.sv
+++ b/rtl/system/dm_top.sv
@@ -13,8 +13,9 @@
 `include "prim_assert.sv"
 
 module dm_top #(
-  parameter int              NrHarts = 1,
-  parameter logic [31:0]     IdcodeValue = 32'h 0000_0001
+  parameter int          NrHarts = 1,
+  parameter logic [31:0] IdcodeValue = 32'h 0000_0001,
+  parameter int          BusWidth = 32
 ) (
   input  logic               clk_i,       // clock
   input  logic               rst_ni,      // asynchronous reset active low, connect PoR
@@ -47,7 +48,6 @@ module dm_top #(
 
   `ASSERT_INIT(paramCheckNrHarts, NrHarts > 0)
 
-  localparam int BusWidth = 32;
   // all harts have contiguous IDs
   localparam logic [NrHarts-1:0] SelectableHarts = {NrHarts{1'b1}};
 

--- a/rtl/system/gpio.sv
+++ b/rtl/system/gpio.sv
@@ -5,13 +5,13 @@
 module gpio #(
   GpoWidth = 16
 ) (
-  input logic                 clk_i,
-  input logic                 rst_ni,
+  input  logic                clk_i,
+  input  logic                rst_ni,
 
   input  logic                device_req_i,
   input  logic [31:0]         device_addr_i,
   input  logic                device_we_i,
-  input  logic [3:0]          device_be_i,
+  input  logic [ 3:0]         device_be_i,
   input  logic [31:0]         device_wdata_i,
   output logic                device_rvalid_o,
   output logic [31:0]         device_rdata_o,
@@ -36,7 +36,7 @@ module gpio #(
 
   assign gp_en = device_req_i & device_we_i & (device_addr_i[9:0] == 0);
 
-  for (genvar i_byte = 0;i_byte < 4; ++i_byte) begin : g_gp_d;
+  for (genvar i_byte = 0; i_byte < 4; ++i_byte) begin : g_gp_d;
     if (i_byte * 8 < GpoWidth) begin : g_gp_d_inner
       localparam int gpo_byte_end = (i_byte + 1) * 8 <= GpoWidth ? (i_byte + 1) * 8 : GpoWidth;
       assign gp_d[gpo_byte_end - 1 : i_byte * 8] =

--- a/rtl/system/ibex_demo_system.sv
+++ b/rtl/system/ibex_demo_system.sv
@@ -20,30 +20,36 @@ module ibex_demo_system #(
   output logic [GpoWidth-1:0] gp_o,
   output logic                uart_tx_o
 );
-  localparam logic [31:0] MEM_SIZE     = 64 * 1024; // 64 kB
+  localparam logic [31:0] MEM_SIZE     = 64 * 1024; // 64 KiB
   localparam logic [31:0] MEM_START    = 32'h00100000;
   localparam logic [31:0] MEM_MASK     = ~(MEM_SIZE-1);
 
-  localparam logic [31:0] GPIO_SIZE    = 4 * 1024; // 1kB
+  localparam logic [31:0] GPIO_SIZE    =  4 * 1024; //  4 KiB
   localparam logic [31:0] GPIO_START   = 32'h80000000;
   localparam logic [31:0] GPIO_MASK    = ~(GPIO_SIZE-1);
 
   localparam logic [31:0] DEBUG_START  = 32'h1a110000;
-  localparam logic [31:0] DEBUG_SIZE   = 64 * 1024; // 64 kB
+  localparam logic [31:0] DEBUG_SIZE   = 64 * 1024; // 64 KiB
   localparam logic [31:0] DEBUG_MASK   = ~(DEBUG_SIZE-1);
 
-  localparam logic [31:0] UART_SIZE    = 4 * 1024; // 4kB
+  localparam logic [31:0] UART_SIZE    =  4 * 1024; //  4 KiB
   localparam logic [31:0] UART_START   = 32'h80001000;
   localparam logic [31:0] UART_MASK    = ~(UART_SIZE-1);
 
-  localparam logic [31:0] TIMER_SIZE   = 4 * 1024; // 4kB
+  localparam logic [31:0] TIMER_SIZE   =  4 * 1024; //  4 KiB
   localparam logic [31:0] TIMER_START  = 32'h80002000;
   localparam logic [31:0] TIMER_MASK   = ~(TIMER_SIZE-1);
 
+  // Pulse width modulator parameters
+  localparam logic [31:0] PWM_SIZE     =  4 * 1024; //  4 KiB
+  localparam logic [31:0] PWM_START    = 32'h80003000;
+  localparam logic [31:0] PWM_MASK     = ~(PWM_SIZE-1);
+  localparam int PwmCtrSize = 8;
+
   // debug functionality is optional
   localparam bit DBG = 1;
-  localparam int unsigned DbgHwBreakNum = (DBG == 1) ? 2 : 0;
-  localparam bit DbgTriggerEn = (DBG == 1) ? 1'b1 : 1'b0;
+  localparam int unsigned DbgHwBreakNum = (DBG == 1) ?    2 :    0;
+  localparam bit          DbgTriggerEn  = (DBG == 1) ? 1'b1 : 1'b0;
 
   typedef enum int {
     CoreD,

--- a/rtl/system/ibex_demo_system.sv
+++ b/rtl/system/ibex_demo_system.sv
@@ -20,25 +20,25 @@ module ibex_demo_system #(
   output logic [GpoWidth-1:0] gp_o,
   output logic                uart_tx_o
 );
-  parameter logic [31:0] MEM_SIZE     = 64 * 1024; // 64 kB
-  parameter logic [31:0] MEM_START    = 32'h00100000;
-  parameter logic [31:0] MEM_MASK     = ~(MEM_SIZE-1);
+  localparam logic [31:0] MEM_SIZE     = 64 * 1024; // 64 kB
+  localparam logic [31:0] MEM_START    = 32'h00100000;
+  localparam logic [31:0] MEM_MASK     = ~(MEM_SIZE-1);
 
-  parameter logic [31:0] GPIO_SIZE    = 4 * 1024; // 1kB
-  parameter logic [31:0] GPIO_START   = 32'h80000000;
-  parameter logic [31:0] GPIO_MASK    = ~(GPIO_SIZE-1);
+  localparam logic [31:0] GPIO_SIZE    = 4 * 1024; // 1kB
+  localparam logic [31:0] GPIO_START   = 32'h80000000;
+  localparam logic [31:0] GPIO_MASK    = ~(GPIO_SIZE-1);
 
-  parameter logic [31:0] DEBUG_START  = 32'h1a110000;
-  parameter logic [31:0] DEBUG_SIZE   = 64 * 1024; // 64 kB
-  parameter logic [31:0] DEBUG_MASK   = ~(DEBUG_SIZE-1);
+  localparam logic [31:0] DEBUG_START  = 32'h1a110000;
+  localparam logic [31:0] DEBUG_SIZE   = 64 * 1024; // 64 kB
+  localparam logic [31:0] DEBUG_MASK   = ~(DEBUG_SIZE-1);
 
-  parameter logic [31:0] UART_SIZE    = 4 * 1024; // 4kB
-  parameter logic [31:0] UART_START   = 32'h80001000;
-  parameter logic [31:0] UART_MASK    = ~(UART_SIZE-1);
+  localparam logic [31:0] UART_SIZE    = 4 * 1024; // 4kB
+  localparam logic [31:0] UART_START   = 32'h80001000;
+  localparam logic [31:0] UART_MASK    = ~(UART_SIZE-1);
 
-  parameter logic [31:0] TIMER_SIZE   = 4 * 1024; // 4kB
-  parameter logic [31:0] TIMER_START  = 32'h80002000;
-  parameter logic [31:0] TIMER_MASK   = ~(TIMER_SIZE-1);
+  localparam logic [31:0] TIMER_SIZE   = 4 * 1024; // 4kB
+  localparam logic [31:0] TIMER_START  = 32'h80002000;
+  localparam logic [31:0] TIMER_MASK   = ~(TIMER_SIZE-1);
 
   // debug functionality is optional
   localparam bit DBG = 1;
@@ -198,9 +198,9 @@ module ibex_demo_system #(
      .clk_i                 (clk_sys_i),
      .rst_ni                (rst_core_n),
 
-     .test_en_i             ('b0),
+     .test_en_i             (1'b0),
      .scan_rst_ni           (1'b1),
-     .ram_cfg_i             ('b0),
+     .ram_cfg_i             (10'b0),
 
      .hart_id_i             (32'b0),
      // First instruction executed is at 0x0 + 0x80
@@ -211,7 +211,7 @@ module ibex_demo_system #(
      .instr_rvalid_i        (core_instr_rvalid),
      .instr_addr_o          (core_instr_addr),
      .instr_rdata_i         (core_instr_rdata),
-     .instr_err_i           ('b0),
+     .instr_err_i           (1'b0),
 
      .data_req_o            (host_req[CoreD]),
      .data_gnt_i            (host_gnt[CoreD]),

--- a/rtl/system/pwm.sv
+++ b/rtl/system/pwm.sv
@@ -1,0 +1,42 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module pwm #(
+  parameter int CtrSize = 8
+) (
+  input  logic               clk_i,
+  input  logic               rst_ni,
+
+  // To produce an always-on signal, you will need to make pulse_width_i > max_counter_i.
+  input  logic [CtrSize-1:0] pulse_width_i,
+  input  logic [CtrSize-1:0] max_counter_i,
+
+  output logic               modulated_o
+);
+  logic [CtrSize-1:0] counter;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      counter     <= 'b0;
+      modulated_o <= 'b0;
+    end else if (max_counter_i == 0) begin
+      // Set output to low when maximum is zero.
+      counter     <= 'b0;
+      modulated_o <= 'b0;
+    end else begin
+      // Wrap the counter once it gets to the maximum.
+      if (counter < max_counter_i) begin
+        counter <= counter + 1;
+      end else begin
+        counter <= 0;
+      end
+      // Set output to high for pulse_width_i/max_counter_i amount of time.
+      if (pulse_width_i > counter) begin
+        modulated_o <= 1'b1;
+      end else begin
+        modulated_o <= 1'b0;
+      end
+    end
+  end
+endmodule

--- a/rtl/system/pwm_wrapper.sv
+++ b/rtl/system/pwm_wrapper.sv
@@ -1,0 +1,77 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This wrapper instantiates a series of PWMs and distributes requests from the device bus.
+module pwm_wrapper #(
+  parameter int PwmWidth   = 12,
+  parameter int PwmCtrSize = 8,
+  parameter int BusWidth   = 32
+) (
+  input  logic                clk_i,
+  input  logic                rst_ni,
+
+  // IO for device bus.
+  input  logic                device_req_i,
+  input  logic [BusWidth-1:0] device_addr_i,
+  input  logic                device_we_i,
+  input  logic [         3:0] device_be_i,
+  input  logic [BusWidth-1:0] device_wdata_i,
+  output logic                device_rvalid_o,
+  output logic [BusWidth-1:0] device_rdata_o,
+
+  // Collected output of all PWMs.
+  output logic [PwmWidth-1:0] pwm_o
+);
+  // Generate PwmWidth number of PWMs.
+  for (genvar i = 0; i < PwmWidth; i++) begin : gen_pwm
+    logic [PwmCtrSize-1:0] data_d;
+    logic [PwmCtrSize-1:0] counter_q;
+    logic [PwmCtrSize-1:0] pulse_width_q;
+    logic pwm_en;
+    logic counter_en;
+    logic pulse_width_en;
+
+    // Byte enables are currently unsupported for PWM.
+    assign data_d         = device_wdata_i[PwmCtrSize-1:0]; // Only take PwmCtrSize LSBs.
+    // Each PWM has a 64-bit block. The most significant 32 bits are the counter and the least
+    // significant 32 bits are the pulse width.
+    assign counter_en     = device_req_i & device_we_i & (device_addr_i[9:0] == ((i * 2*BusWidth/8) + BusWidth/8));
+    assign pulse_width_en = device_req_i & device_we_i & (device_addr_i[9:0] == (i * 2*BusWidth/8));
+
+    always @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        counter_q       <= '0;
+        pulse_width_q   <= '0;
+      end else begin
+        if (counter_en) begin
+          counter_q     <= data_d;
+        end
+        if (pulse_width_en) begin
+          pulse_width_q <= data_d;
+        end
+      end
+    end
+    pwm #(
+      .CtrSize( PwmCtrSize )
+    ) u_pwm (
+      .clk_i        (clk_i),
+      .rst_ni       (rst_ni),
+      .pulse_width_i(pulse_width_q),
+      .max_counter_i(counter_q),
+      .modulated_o  (pwm_o[i])
+    );
+  end : gen_pwm
+
+  // Generating the device bus output.
+  // Reading from PWM currently not possible.
+  assign device_rdata_o = 32'b0;
+  always @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      device_rvalid_o <= 1'b0;
+    end else begin
+      // TODO only set rvalid if rdata was valid.
+      device_rvalid_o <= device_req_i;
+    end
+  end
+endmodule

--- a/sw/common/CMakeLists.txt
+++ b/sw/common/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(common OBJECT demo_system.c uart.c timer.c gpio.c crt0.S)
+add_library(common OBJECT demo_system.c uart.c timer.c gpio.c pwm.c crt0.S)
 set_property(SOURCE crt0.S PROPERTY LANGUAGE C)
 target_include_directories(common PUBLIC "${CMAKE_CURRENT_LIST_DIR}")

--- a/sw/common/demo_system.h
+++ b/sw/common/demo_system.h
@@ -18,6 +18,9 @@
 
 #define TIMER_BASE 0x80002000
 
+#define PWM_BASE   0x80003000
+#define NUM_PWM_MODULES 12
+
 /**
  * Writes character to default UART. Signature matches c stdlib function
  * of the same name.

--- a/sw/common/link.ld
+++ b/sw/common/link.ld
@@ -6,9 +6,9 @@ OUTPUT_ARCH(riscv)
 
 MEMORY
 {
-    /* 60 kB should be enough for anybody... */
-    ram         : ORIGIN = 0x00100000, LENGTH = 0xE000 /* 56 kB */
-    stack       : ORIGIN = 0x0010E000, LENGTH = 0x2000  /* 4 kB */
+    /* 60 KiB should be enough for anybody... */
+    ram         : ORIGIN = 0x00100000, LENGTH = 0xE000 /* 56 KiB */
+    stack       : ORIGIN = 0x0010E000, LENGTH = 0x2000  /* 4 KiB */
 }
 
 /* Stack information variables */

--- a/sw/common/pwm.c
+++ b/sw/common/pwm.c
@@ -1,0 +1,11 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "pwm.h"
+#include "dev_access.h"
+
+void set_pwm(pwm_t pwm, uint32_t counter, uint32_t pulse_width) {
+  DEV_WRITE(&pwm[1], counter);
+  DEV_WRITE(&pwm[0], pulse_width);
+}

--- a/sw/common/pwm.h
+++ b/sw/common/pwm.h
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef PWM_H__
+#define PWM_H__
+
+#include <stdint.h>
+
+typedef uint32_t* pwm_t;
+
+#define PWM_FROM_ADDR_AND_INDEX(addr, index)(&(((pwm_t) addr)[2*index]))
+
+void set_pwm(pwm_t pwm, uint32_t counter, uint32_t pulse_width);
+
+#endif

--- a/sw/demo/main.c
+++ b/sw/demo/main.c
@@ -1,31 +1,68 @@
 #include "demo_system.h"
 #include "timer.h"
 #include "gpio.h"
+#include "pwm.h"
+#include <stdbool.h>
 
 int main(void) {
+  // This indicates how often the timer gets updated.
   timer_init();
-  timer_enable(50000000);
+  timer_enable(5000000);
 
   uint64_t last_elapsed_time = get_elapsed_time();
   uint32_t cur_output_bit = 1;
   uint32_t cur_output_bit_index = 0;
 
+  // Reset green LEDs to off
   set_outputs(GPIO0, 0x0);
+
+  // PWM variables
+  uint32_t counter = UINT8_MAX;
+  uint32_t brightness = 0;
+  bool ascending = true;
+  // The three least significant bits correspond to RGB, where B is the leas significant.
+  uint8_t color = 7;
 
   while(1) {
     uint64_t cur_time = get_elapsed_time();
 
     if (cur_time != last_elapsed_time) {
       last_elapsed_time = cur_time;
+
+      // Print this to UART (use the screen command to see it).
       puts("Hello World! ");
       puthex(last_elapsed_time);
       putchar('\n');
-      set_output_bit(GPIO0, cur_output_bit_index, cur_output_bit);
 
+      // Cycling through green LEDs
+      set_output_bit(GPIO0, cur_output_bit_index, cur_output_bit);
       cur_output_bit_index++;
-      if (cur_output_bit_index >= 16) {
+      if (cur_output_bit_index >= 4) {
         cur_output_bit_index = 0;
         cur_output_bit = !cur_output_bit;
+      }
+
+      // Going from bright to dim on PWM
+      for(int i = 0; i < NUM_PWM_MODULES; i++) {
+        set_pwm(PWM_FROM_ADDR_AND_INDEX(PWM_BASE, i),
+            ((1 << (i%3)) & color) ? counter : 0,
+            brightness ? 1 << (brightness - 1) : 0);
+      }
+      if (ascending) {
+        brightness++;
+        if (brightness >= 5) {
+          ascending = false;
+        }
+      } else {
+        brightness--;
+        // When LEDs are off cycle through the colors
+        if (brightness == 0) {
+          ascending = true;
+          color++;
+          if (color >= 8) {
+            color = 1;
+          }
+        }
       }
     }
 


### PR DESCRIPTION
This PR supersedes the PR that got closed when the demo system became public: https://github.com/lowRISC/ibex-demo-system/pull/2

Added pulse width modulation to RGB LEDs, which are controlled by the switches. I also added a way for the buttons to control the green LEDs.

The LEDs are very bright by default, so I had to set the default pulse width quite short. That's why the switches only control the least significant bits in the pulse width.

I could integrate this into the GPIO module if that is desired.