### PR TITLE
Move python venv to ./venv dir, add backup programming command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-bin/
 build/
-lib/
-lib64
-pyvenv.cfg
-share/
 sw/build/
+.venv/

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ recommended)
 
 ```bash
 # Setup python venv
-python3 -m venv .
-source ./bin/activate
+python3 -m venv .venv
+source .venv/bin/activate
 
 # Install python requirements
 pip3 install -r python-requirements.txt
@@ -50,11 +50,11 @@ First the software must be built. This is provide an initial binary for the FPGA
 build.
 
 ```
-cd sw
-mkdir build
-cd build
+mkdir sw/build
+pushd sw/build
 cmake ../
 make
+popd
 ```
 
 Note the FPGA build relies on a fixed path to the initial binary (blank.vmem) so

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ To program the FPGA, either use FuseSoC again
 
 ```
 fusesoc --cores-root=. run --target=synth --run lowrisc:ibex:demo_system
+
+# If the above does not work, try executing the programming operation manually with..
+make -C ./build/lowrisc_ibex_demo_system_0/synth-vivado/ pgm
 ```
 
 Or use the Vivado GUI


### PR DESCRIPTION
I'm not sure why the fusesoc --run command does not work to program the hardware for me during testing, but manually reaching in and running the generated 'make pgm' command does work, so add it as a commented suggestion.