### PR TITLE
[verilator] Use simctrl to halt sim after main

### DIFF
--- a/sw/common/crt0.S
+++ b/sw/common/crt0.S
@@ -1,6 +1,7 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+#include "demo_system_regs.h"
 
 .section .text
 
@@ -65,6 +66,11 @@ main_entry:
   addi x10, x0, 0
   addi x11, x0, 0
   jal x1, main
+
+  /* Halt simulation */
+  li x5, SIM_CTRL_BASE + SIM_CTRL_CTRL
+  li x6, 1
+  sw x6, 0(x5)
 
   /* If execution ends up here just put the core to sleep */
 sleep_loop:

--- a/sw/common/demo_system.c
+++ b/sw/common/demo_system.c
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "demo_system.h"
+#include "dev_access.h"
 #include "uart.h"
 
 int putchar(int c) {
@@ -42,6 +43,8 @@ void puthex(uint32_t h) {
     h <<= 4;
   }
 }
+
+void sim_halt() { DEV_WRITE(SIM_CTRL_BASE + SIM_CTRL_CTRL, 1); }
 
 unsigned int get_mepc() {
   uint32_t result;

--- a/sw/common/demo_system.h
+++ b/sw/common/demo_system.h
@@ -7,27 +7,23 @@
 
 #include <stdint.h>
 
+#include "demo_system_regs.h"
 #include "uart.h"
 #include "gpio.h"
 
-#define UART0_BASE 0x80001000
 #define UART_IRQ_NUM 16
 #define UART_IRQ (1 << UART_IRQ_NUM)
 #define DEFAULT_UART UART_FROM_BASE_ADDR(UART0_BASE)
 
-#define GPIO_BASE 0x80000000
 #define GPIO_OUT GPIO_FROM_BASE_ADDR(GPIO_BASE + GPIO_OUT_REG)
 #define GPIO_IN GPIO_FROM_BASE_ADDR(GPIO_BASE + GPIO_IN_REG)
 #define GPIO_IN_DBNC GPIO_FROM_BASE_ADDR(GPIO_BASE + GPIO_IN_DBNC_REG)
 #define GPIO_OUT_SHIFT GPIO_FROM_BASE_ADDR(GPIO_BASE + GPIO_OUT_SHIFT_REG)
 
-#define TIMER_BASE 0x80002000
 #define TIMER_IRQ (1 << 7)
 
-#define PWM_BASE   0x80003000
 #define NUM_PWM_MODULES 12
 
-#define SPI0_BASE 0x80004000
 #define DEFAULT_SPI SPI_FROM_BASE_ADDR(SPI0_BASE)
 
 /**
@@ -46,6 +42,11 @@ int putchar(int c);
  * @returns Character from the uart rx fifo
  */
 int getchar(void);
+
+/**
+ * Immediately halts the simulation
+ */
+void sim_halt();
 
 /**
  * Writes string to default UART. Signature matches c stdlib function of

--- a/sw/common/demo_system_regs.h
+++ b/sw/common/demo_system_regs.h
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef DEMO_SYSTEM_REGS_H__
+#define DEMO_SYSTEM_REGS_H__
+
+#define UART0_BASE 0x80001000
+
+#define GPIO_BASE 0x80000000
+
+#define TIMER_BASE 0x80002000
+
+#define PWM_BASE   0x80003000
+
+#define SPI0_BASE 0x80004000
+
+#define SIM_CTRL_BASE 0x20000
+#define SIM_CTRL_OUT 0x0
+#define SIM_CTRL_CTRL 0x8
+
+#endif


### PR DESCRIPTION
Adds simulation halting in Verilator after main program execution by adding a snippet to `crt0.S`. Same trick already exists in simple_system examples.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>

Can be tested by simply removing the `while(1)` loop in demo `main.c`, building with Verilator and see the simulation end on its own.