### PR TITLE
[sw] Rename floating point fractal function and source file

### DIFF
--- a/sw/demo/lcd_st7735/CMakeLists.txt
+++ b/sw/demo/lcd_st7735/CMakeLists.txt
@@ -7,7 +7,7 @@ ${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/display_drivers/st7735/lcd_st7735.c
 )
 
 # add_executable(lcd_st7735 main.c)
-add_prog(lcd_st7735 "main.c;lcd.c;fractal.c")
+add_prog(lcd_st7735 "main.c;lcd.c;fractal_float.c")
 
 # pull in core dependencies and additional i2c hardware support
 target_link_libraries(lcd_st7735 lcd_st7735_lib)

--- a/sw/demo/lcd_st7735/fractal.h
+++ b/sw/demo/lcd_st7735/fractal.h
@@ -6,7 +6,7 @@
 
 #include "lcd.h"
 
-void fractal_mandelbrot(St7735Context *lcd, bool by_pixel);
+void fractal_mandelbrot_float(St7735Context *lcd, bool by_pixel);
 
 void fractal_bifurcation(St7735Context *lcd);
 

--- a/sw/demo/lcd_st7735/fractal_float.c
+++ b/sw/demo/lcd_st7735/fractal_float.c
@@ -30,7 +30,7 @@
 #define RGB_COMPONENT_COLOR 255		// each component of the RGB color model defines the intensity of the color between 0-255
 
 // Function to draw fractal_mandelbrot set
-void fractal_mandelbrot(St7735Context *lcd, bool by_pixel)
+void fractal_mandelbrot_float(St7735Context *lcd, bool by_pixel)
 {
     lcd_st7735_clean(lcd);
     LCD_rectangle rectangle = {.origin = {.x = 0, .y = 0},

--- a/sw/demo/lcd_st7735/main.c
+++ b/sw/demo/lcd_st7735/main.c
@@ -125,7 +125,7 @@ static void fractal_test(St7735Context *lcd){
     fractal_bifurcation(lcd);
     timer_delay(2000); 
 
-    fractal_mandelbrot(lcd, true);
+    fractal_mandelbrot_float(lcd, true);
     timer_delay(5000); 
 }
 


### PR DESCRIPTION
Appending `_float` to the name of the function and source file of the code of the floating point Mandelbrot implementation makes room for other implementations.