### PR TITLE
[sw] Fix return value of `spi_write`

### DIFF
--- a/sw/demo/lcd_st7735/main.c
+++ b/sw/demo/lcd_st7735/main.c
@@ -145,10 +145,12 @@ static Buttons_t scan_buttons(uint32_t timeout){
 }
 
 static uint32_t spi_write(void *handle, uint8_t *data, size_t len){
+  const uint32_t data_sent = len;
   while(len--){
     spi_send_byte_blocking(handle, *data++);
   }
   while((spi_get_status(handle) & spi_status_fifo_empty) != spi_status_fifo_empty);
+  return data_sent;
 }
 
 static uint32_t gpio_write(void *handle, bool cs, bool dc){


### PR DESCRIPTION
This function should return the "number of data sent", according to the documentation in `vendor/display_drivers/core/lcd_base.h`.

Fixing this removes a compile-time warning.