### PR TITLE
[vendor/display_drivers] Fix return value of `lcd_st7735_set_orientation`

### DIFF
--- a/vendor/display_drivers/st7735/lcd_st7735.c
+++ b/vendor/display_drivers/st7735/lcd_st7735.c
@@ -96,6 +96,7 @@ Result lcd_st7735_set_orientation(St7735Context *ctx, LCD_Orientation orientatio
   };
 
   write_register(ctx, ST7735_MADCTL, st7735_orientation_map[orientation] | ST77_MADCTL_RGB);
+  return (Result){.code = 0};
 }
 
 Result lcd_st7735_clean(St7735Context *ctx) {


### PR DESCRIPTION
This fix removes a compile-time warning.

This should ideally be fixed upstream and vendored back in, but in the interest of time I propose this direct fix.  We can create an issue to track upstream resolution.