### PR TITLE
Add NewAE targets and applications

### DIFF
--- a/data/pins_cw305.xdc
+++ b/data/pins_cw305.xdc
@@ -1,0 +1,37 @@
+## Clock signal
+set_property -dict { PACKAGE_PIN F5   IOSTANDARD LVCMOS33 } [get_ports { IO_CLK }]; # USB clock (96 MHz)
+create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports { IO_CLK }];
+
+## Switches
+set_property -dict { PACKAGE_PIN J16   IOSTANDARD LVCMOS33 } [get_ports { SW[0] }]; #IO_L12N_T1_MRCC_16 Sch=sw[0]
+set_property -dict { PACKAGE_PIN K16   IOSTANDARD LVCMOS33 } [get_ports { SW[1] }]; #IO_L13P_T2_MRCC_16 Sch=sw[1]
+set_property -dict { PACKAGE_PIN L14   IOSTANDARD LVCMOS33 } [get_ports { SW[2] }]; #IO_L13N_T2_MRCC_16 Sch=sw[2]
+set_property -dict { PACKAGE_PIN K15   IOSTANDARD LVCMOS33 } [get_ports { SW[3] }]; #IO_L14P_T2_SRCC_16 Sch=sw[3]
+
+## RGB LEDs
+set_property -dict { PACKAGE_PIN B12   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[0]  }]; #IO_L18N_T2_35 Sch=led0_b
+set_property -dict { PACKAGE_PIN A13   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[1]  }]; #IO_L19N_T3_VREF_35 Sch=led0_g
+set_property -dict { PACKAGE_PIN B15   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[2]  }]; #IO_L19P_T3_35 Sch=led0_r
+set_property -dict { PACKAGE_PIN C11   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[3]  }]; #IO_L20P_T3_35 Sch=led1_b
+set_property -dict { PACKAGE_PIN C14   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[4]  }]; #IO_L21P_T3_DQS_35 Sch=led1_g
+set_property -dict { PACKAGE_PIN C16   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[5]  }]; #IO_L20N_T3_35 Sch=led1_r
+set_property -dict { PACKAGE_PIN D13   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[6]  }]; #IO_L21N_T3_DQS_35 Sch=led2_b
+set_property -dict { PACKAGE_PIN H16   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[7]  }]; #IO_L22N_T3_35 Sch=led2_g
+set_property -dict { PACKAGE_PIN D16   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[8]  }]; #IO_L22P_T3_35 Sch=led2_r
+set_property -dict { PACKAGE_PIN E16   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[9]  }]; #IO_L23P_T3_35 Sch=led3_b
+set_property -dict { PACKAGE_PIN F12   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[10] }]; #IO_L24P_T3_35 Sch=led3_g
+set_property -dict { PACKAGE_PIN F13   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[11] }]; #IO_L23N_T3_35 Sch=led3_r
+
+## LEDs
+set_property -dict { PACKAGE_PIN T2    IOSTANDARD LVCMOS33 } [get_ports { LED[0] }]; #IO_L24N_T3_35 Sch=led[4]
+set_property -dict { PACKAGE_PIN T3    IOSTANDARD LVCMOS33 } [get_ports { LED[1] }]; #IO_25_35 Sch=led[5]
+set_property -dict { PACKAGE_PIN T4    IOSTANDARD LVCMOS33 } [get_ports { LED[2] }]; #IO_L24P_T3_A01_D17_14 Sch=led[6]
+
+set_property DRIVE 8 [get_ports LED*]
+
+## UART
+set_property -dict { PACKAGE_PIN P16   IOSTANDARD LVCMOS33 } [get_ports { UART_TX }]; #CW IO1
+set_property -dict { PACKAGE_PIN R16   IOSTANDARD LVCMOS33 } [get_ports { UART_RX }]; #CW IO2
+
+set_property -dict { PACKAGE_PIN R1    IOSTANDARD LVCMOS33 } [get_ports { IO_RST_N }]; #IO_L16P_T2_35 Sch=ck_rst
+

--- a/data/pins_cw305.xdc
+++ b/data/pins_cw305.xdc
@@ -1,26 +1,15 @@
-## Clock signal
-set_property -dict { PACKAGE_PIN F5   IOSTANDARD LVCMOS33 } [get_ports { IO_CLK }]; # USB clock (96 MHz)
-create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports { IO_CLK }];
+## Clocks
+set_property -dict { PACKAGE_PIN N13   IOSTANDARD LVCMOS33 } [get_ports { I_pll_clk1 }];
+set_property -dict { PACKAGE_PIN N14   IOSTANDARD LVCMOS33 } [get_ports { I_cw_clkin }];
+
+create_clock -period 10.000 -name pll_clk1 -waveform {0.000 5.000} [get_nets I_pll_clk1]
+create_clock -period 10.000 -name cw_clkin -waveform {0.000 5.000} [get_nets I_cw_clkin]
 
 ## Switches
-set_property -dict { PACKAGE_PIN J16   IOSTANDARD LVCMOS33 } [get_ports { SW[0] }]; #IO_L12N_T1_MRCC_16 Sch=sw[0]
-set_property -dict { PACKAGE_PIN K16   IOSTANDARD LVCMOS33 } [get_ports { SW[1] }]; #IO_L13P_T2_MRCC_16 Sch=sw[1]
-set_property -dict { PACKAGE_PIN L14   IOSTANDARD LVCMOS33 } [get_ports { SW[2] }]; #IO_L13N_T2_MRCC_16 Sch=sw[2]
-set_property -dict { PACKAGE_PIN K15   IOSTANDARD LVCMOS33 } [get_ports { SW[3] }]; #IO_L14P_T2_SRCC_16 Sch=sw[3]
-
-## RGB LEDs
-set_property -dict { PACKAGE_PIN B12   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[0]  }]; #IO_L18N_T2_35 Sch=led0_b
-set_property -dict { PACKAGE_PIN A13   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[1]  }]; #IO_L19N_T3_VREF_35 Sch=led0_g
-set_property -dict { PACKAGE_PIN B15   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[2]  }]; #IO_L19P_T3_35 Sch=led0_r
-set_property -dict { PACKAGE_PIN C11   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[3]  }]; #IO_L20P_T3_35 Sch=led1_b
-set_property -dict { PACKAGE_PIN C14   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[4]  }]; #IO_L21P_T3_DQS_35 Sch=led1_g
-set_property -dict { PACKAGE_PIN C16   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[5]  }]; #IO_L20N_T3_35 Sch=led1_r
-set_property -dict { PACKAGE_PIN D13   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[6]  }]; #IO_L21N_T3_DQS_35 Sch=led2_b
-set_property -dict { PACKAGE_PIN H16   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[7]  }]; #IO_L22N_T3_35 Sch=led2_g
-set_property -dict { PACKAGE_PIN D16   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[8]  }]; #IO_L22P_T3_35 Sch=led2_r
-set_property -dict { PACKAGE_PIN E16   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[9]  }]; #IO_L23P_T3_35 Sch=led3_b
-set_property -dict { PACKAGE_PIN F12   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[10] }]; #IO_L24P_T3_35 Sch=led3_g
-set_property -dict { PACKAGE_PIN F13   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[11] }]; #IO_L23N_T3_35 Sch=led3_r
+set_property -dict { PACKAGE_PIN J16   IOSTANDARD LVCMOS33 } [get_ports { J16 }]; #IO_L12N_T1_MRCC_16 Sch=sw[0]
+set_property -dict { PACKAGE_PIN K16   IOSTANDARD LVCMOS33 } [get_ports { K16 }]; #IO_L13P_T2_MRCC_16 Sch=sw[1]
+set_property -dict { PACKAGE_PIN L14   IOSTANDARD LVCMOS33 } [get_ports { L14 }]; #IO_L13N_T2_MRCC_16 Sch=sw[2]
+set_property -dict { PACKAGE_PIN K15   IOSTANDARD LVCMOS33 } [get_ports { K15 }]; #IO_L14P_T2_SRCC_16 Sch=sw[3]
 
 ## LEDs
 set_property -dict { PACKAGE_PIN T2    IOSTANDARD LVCMOS33 } [get_ports { LED[0] }]; #IO_L24N_T3_35 Sch=led[4]
@@ -33,5 +22,11 @@ set_property DRIVE 8 [get_ports LED*]
 set_property -dict { PACKAGE_PIN P16   IOSTANDARD LVCMOS33 } [get_ports { UART_TX }]; #CW IO1
 set_property -dict { PACKAGE_PIN R16   IOSTANDARD LVCMOS33 } [get_ports { UART_RX }]; #CW IO2
 
+# IO3-4:
+set_property -dict { PACKAGE_PIN T15   IOSTANDARD LVCMOS33 } [get_ports { IO3 }]; #IO3
+set_property -dict { PACKAGE_PIN T14   IOSTANDARD LVCMOS33 } [get_ports { IO4 }]; #IO4
+
+
 set_property -dict { PACKAGE_PIN R1    IOSTANDARD LVCMOS33 } [get_ports { IO_RST_N }]; #IO_L16P_T2_35 Sch=ck_rst
 
+set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]

--- a/data/pins_cw312a35.xdc
+++ b/data/pins_cw312a35.xdc
@@ -1,0 +1,38 @@
+## Clock signal
+set_property -dict { PACKAGE_PIN D15  IOSTANDARD LVCMOS33 } [get_ports { IO_CLK }]; # HS2 pin
+create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports { IO_CLK }];
+
+## Switches
+# IO3-4:
+set_property -dict { PACKAGE_PIN V12   IOSTANDARD LVCMOS33 } [get_ports { SW[0] }]; #IO3
+set_property -dict { PACKAGE_PIN V14   IOSTANDARD LVCMOS33 } [get_ports { SW[1] }]; #IO4
+
+## RGB LEDs
+# HDR1-10:
+set_property -dict { PACKAGE_PIN L1    IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[0]  }]; #HDR1
+set_property -dict { PACKAGE_PIN M1    IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[1]  }]; #HDR2
+set_property -dict { PACKAGE_PIN N1    IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[2]  }]; #HDR3
+set_property -dict { PACKAGE_PIN T1    IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[3]  }]; #HDR4
+set_property -dict { PACKAGE_PIN U1    IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[4]  }]; #HDR5
+set_property -dict { PACKAGE_PIN V1    IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[5]  }]; #HDR6
+set_property -dict { PACKAGE_PIN V4    IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[6]  }]; #HDR7
+set_property -dict { PACKAGE_PIN V6    IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[7]  }]; #HDR8
+set_property -dict { PACKAGE_PIN V7    IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[8]  }]; #HDR9
+set_property -dict { PACKAGE_PIN V9    IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[9]  }]; #HDR10
+# TRACEDATA0-1:
+set_property -dict { PACKAGE_PIN U18   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[10] }]; #TRACEDATA0
+set_property -dict { PACKAGE_PIN T18   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[11] }]; #TRACEDATA1
+
+## LEDs
+set_property -dict { PACKAGE_PIN R1    IOSTANDARD LVCMOS33 } [get_ports { LED[0] }];
+set_property -dict { PACKAGE_PIN V2    IOSTANDARD LVCMOS33 } [get_ports { LED[1] }];
+set_property -dict { PACKAGE_PIN V5    IOSTANDARD LVCMOS33 } [get_ports { LED[2] }];
+
+set_property DRIVE 8 [get_ports LED*]
+
+## UART
+set_property -dict { PACKAGE_PIN V10   IOSTANDARD LVCMOS33 } [get_ports { UART_TX }]; #CW IO1
+set_property -dict { PACKAGE_PIN V11   IOSTANDARD LVCMOS33 } [get_ports { UART_RX }]; #CW IO2
+
+set_property -dict { PACKAGE_PIN A16   IOSTANDARD LVCMOS33 } [get_ports { IO_RST_N }];
+

--- a/data/pins_cw312a35.xdc
+++ b/data/pins_cw312a35.xdc
@@ -4,24 +4,8 @@ create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports { I
 
 ## Switches
 # IO3-4:
-set_property -dict { PACKAGE_PIN V12   IOSTANDARD LVCMOS33 } [get_ports { SW[0] }]; #IO3
-set_property -dict { PACKAGE_PIN V14   IOSTANDARD LVCMOS33 } [get_ports { SW[1] }]; #IO4
-
-## RGB LEDs
-# HDR1-10:
-set_property -dict { PACKAGE_PIN L1    IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[0]  }]; #HDR1
-set_property -dict { PACKAGE_PIN M1    IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[1]  }]; #HDR2
-set_property -dict { PACKAGE_PIN N1    IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[2]  }]; #HDR3
-set_property -dict { PACKAGE_PIN T1    IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[3]  }]; #HDR4
-set_property -dict { PACKAGE_PIN U1    IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[4]  }]; #HDR5
-set_property -dict { PACKAGE_PIN V1    IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[5]  }]; #HDR6
-set_property -dict { PACKAGE_PIN V4    IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[6]  }]; #HDR7
-set_property -dict { PACKAGE_PIN V6    IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[7]  }]; #HDR8
-set_property -dict { PACKAGE_PIN V7    IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[8]  }]; #HDR9
-set_property -dict { PACKAGE_PIN V9    IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[9]  }]; #HDR10
-# TRACEDATA0-1:
-set_property -dict { PACKAGE_PIN U18   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[10] }]; #TRACEDATA0
-set_property -dict { PACKAGE_PIN T18   IOSTANDARD LVCMOS33 } [get_ports { RGB_LED[11] }]; #TRACEDATA1
+set_property -dict { PACKAGE_PIN V12   IOSTANDARD LVCMOS33 } [get_ports { IO3 }]; #IO3
+set_property -dict { PACKAGE_PIN V14   IOSTANDARD LVCMOS33 } [get_ports { IO4 }]; #IO4
 
 ## LEDs
 set_property -dict { PACKAGE_PIN R1    IOSTANDARD LVCMOS33 } [get_ports { LED[0] }];
@@ -35,4 +19,6 @@ set_property -dict { PACKAGE_PIN V10   IOSTANDARD LVCMOS33 } [get_ports { UART_T
 set_property -dict { PACKAGE_PIN V11   IOSTANDARD LVCMOS33 } [get_ports { UART_RX }]; #CW IO2
 
 set_property -dict { PACKAGE_PIN A16   IOSTANDARD LVCMOS33 } [get_ports { IO_RST_N }];
+
+set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
 

--- a/ibex_demo_system.core
+++ b/ibex_demo_system.core
@@ -73,8 +73,6 @@ parameters:
     datatype: str
     description: SRAM initialization file in vmem hex format
     default: "../../../../../sw/build/blank/blank.vmem"
-    #default: "../../../../../sw/build/demo/hello_world/demo.vmem"
-    #default: "../../../../../sw/build/demo/simpleserial-aes/simpleserial-aes.vmem"
     paramtype: vlogparam
 
   # For value definition, please see ip/prim/rtl/prim_pkg.sv

--- a/ibex_demo_system.core
+++ b/ibex_demo_system.core
@@ -17,6 +17,14 @@ filesets:
       - rtl/fpga/top_artya7.sv
     file_type: systemVerilogSource
 
+  files_xilinx_cw305:
+    depend:
+      - lowrisc:ibex:rv_timer
+      - lowrisc:ibex:fpga_xilinx_shared
+    files:
+      - rtl/fpga/top_cw305.sv
+    file_type: systemVerilogSource
+
   files_verilator:
     depend:
       - lowrisc:ibex:sim_shared
@@ -34,6 +42,12 @@ filesets:
       - data/pins_artya7.xdc
     file_type: xdc
 
+  files_constraints_cw305:
+    files:
+      - data/pins_cw305.xdc
+    file_type: xdc
+
+
 parameters:
   # XXX: This parameter needs to be absolute, or relative to the *.runs/synth_1
   # directory. It's best to pass it as absolute path when invoking fusesoc, e.g.
@@ -44,7 +58,8 @@ parameters:
   SRAMInitFile:
     datatype: str
     description: SRAM initialization file in vmem hex format
-    default: "../../../../../sw/build/blank/blank.vmem"
+    #default: "../../../../../sw/build/blank/blank.vmem"
+    default: "../../../../../sw/build/demo/hello_world/demo.vmem"
     paramtype: vlogparam
 
   # For value definition, please see ip/prim/rtl/prim_pkg.sv
@@ -67,6 +82,20 @@ targets:
     tools:
       vivado:
         part: "xc7a35tcsg324-1"  # Default to Arty A7-35
+    parameters:
+      - SRAMInitFile
+      - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx
+  synth_cw305:
+    <<: *default_target
+    default_tool: vivado
+    filesets_append:
+      - files_xilinx_cw305
+      - files_constraints_cw305
+    toplevel: top_cw305
+    tools:
+      vivado:
+        part: "xc7a100tftg256-2"
+        #part: "xc7a35tftg256-2"
     parameters:
       - SRAMInitFile
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx

--- a/ibex_demo_system.core
+++ b/ibex_demo_system.core
@@ -25,6 +25,14 @@ filesets:
       - rtl/fpga/top_cw305.sv
     file_type: systemVerilogSource
 
+  files_xilinx_cw312a35:
+    depend:
+      - lowrisc:ibex:rv_timer
+      - lowrisc:ibex:fpga_xilinx_shared
+    files:
+      - rtl/fpga/top_cw312a35.sv
+    file_type: systemVerilogSource
+
   files_verilator:
     depend:
       - lowrisc:ibex:sim_shared
@@ -46,6 +54,12 @@ filesets:
     files:
       - data/pins_cw305.xdc
     file_type: xdc
+
+  files_constraints_cw312a35:
+    files:
+      - data/pins_cw312a35.xdc
+    file_type: xdc
+
 
 
 parameters:
@@ -99,6 +113,20 @@ targets:
     parameters:
       - SRAMInitFile
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx
+  synth_cw312a35:
+    <<: *default_target
+    default_tool: vivado
+    filesets_append:
+      - files_xilinx_cw312a35
+      - files_constraints_cw312a35
+    toplevel: top_cw312a35
+    tools:
+      vivado:
+        part: "xc7a35tcsg324-1"
+    parameters:
+      - SRAMInitFile
+      - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx
+
   sim:
     <<: *default_target
     default_tool: verilator

--- a/ibex_demo_system.core
+++ b/ibex_demo_system.core
@@ -72,8 +72,9 @@ parameters:
   SRAMInitFile:
     datatype: str
     description: SRAM initialization file in vmem hex format
-    #default: "../../../../../sw/build/blank/blank.vmem"
-    default: "../../../../../sw/build/demo/hello_world/demo.vmem"
+    default: "../../../../../sw/build/blank/blank.vmem"
+    #default: "../../../../../sw/build/demo/hello_world/demo.vmem"
+    #default: "../../../../../sw/build/demo/simpleserial-aes/simpleserial-aes.vmem"
     paramtype: vlogparam
 
   # For value definition, please see ip/prim/rtl/prim_pkg.sv
@@ -108,8 +109,8 @@ targets:
     toplevel: top_cw305
     tools:
       vivado:
-        part: "xc7a100tftg256-2"
-        #part: "xc7a35tftg256-2"
+        part: "xc7a100tftg256-2" # default to a100 part
+        #part: "xc7a35tftg256-2" # a35 option
     parameters:
       - SRAMInitFile
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx

--- a/rtl/fpga/top_cw305.sv
+++ b/rtl/fpga/top_cw305.sv
@@ -5,34 +5,46 @@
 // This is the top level SystemVerilog file that connects the IO on the board to the Ibex Demo System.
 module top_cw305 (
   // These inputs are defined in data/pins_cw305.xdc
-  input               IO_CLK,
-  input               IO_RST_N,
-  input  [ 3:0]       SW,
-  output [ 2:0]       LED,
-  output [11:0]       RGB_LED,
-  input               UART_RX,
-  output              UART_TX
+  input  logic          I_pll_clk1,
+  input  logic          I_cw_clkin,
+  input  logic          IO_RST_N,
+  input  logic          IO3,
+  input  logic          J16,
+  input  logic          K16,
+  input  logic          L14,
+  input  logic          K15,
+  output logic          IO4,
+  output logic [ 2:0]   LED,
+  input  logic          UART_RX,
+  output logic          UART_TX
 );
   parameter SRAMInitFile = "";
 
   logic clk_sys, rst_sys_n;
+  reg [24:0] clock_heartbeat;
+
+  assign LED[0] = clock_heartbeat[24];
+  assign LED[1] = ~UART_RX || ~UART_TX;
+  assign LED[2] = IO4;
+
+  always @(posedge clk_sys) clock_heartbeat <= clock_heartbeat +  25'd1;
 
   // Instantiating the Ibex Demo System.
   ibex_demo_system #(
-    .GpiWidth(3),
-    .GpoWidth(3),
-    .PwmWidth(12),
+    .GpiWidth(5),
+    .GpoWidth(1),
+    .PwmWidth(1),
     .SRAMInitFile(SRAMInitFile)
   ) u_ibex_demo_system (
     //input
     .clk_sys_i(clk_sys),
     .rst_sys_ni(rst_sys_n),
-    .gp_i(SW),
+    .gp_i({IO3, K15, L14, K16, J16}),
     .uart_rx_i(UART_RX),
 
     //output
-    .gp_o(LED),
-    .pwm_o(RGB_LED),
+    .gp_o(IO4),
+    .pwm_o(),
     .uart_tx_o(UART_TX),
 
     .spi_rx_i(1'b0),
@@ -40,9 +52,19 @@ module top_cw305 (
     .spi_sck_o()
   );
 
+  // clock source select:
+  logic chosen_clock;
+  BUFGMUX_CTRL U_clock_source_select (
+     .O         (chosen_clock),
+     .I0        (I_pll_clk1),
+     .I1        (I_cw_clkin),
+     .S         (J16) // J16 selects the clock; 0=on-board PLL, 1=from CW HS2 pin
+  );    
+
+
   // Generating the system clock and reset for the FPGA.
   clkgen_xil7series clkgen(
-    .IO_CLK,
+    .IO_CLK     (chosen_clock),
     .IO_RST_N,
     .clk_sys,
     .rst_sys_n

--- a/rtl/fpga/top_cw305.sv
+++ b/rtl/fpga/top_cw305.sv
@@ -1,0 +1,51 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This is the top level SystemVerilog file that connects the IO on the board to the Ibex Demo System.
+module top_cw305 (
+  // These inputs are defined in data/pins_cw305.xdc
+  input               IO_CLK,
+  input               IO_RST_N,
+  input  [ 3:0]       SW,
+  output [ 2:0]       LED,
+  output [11:0]       RGB_LED,
+  input               UART_RX,
+  output              UART_TX
+);
+  parameter SRAMInitFile = "";
+
+  logic clk_sys, rst_sys_n;
+
+  // Instantiating the Ibex Demo System.
+  ibex_demo_system #(
+    .GpiWidth(3),
+    .GpoWidth(3),
+    .PwmWidth(12),
+    .SRAMInitFile(SRAMInitFile)
+  ) u_ibex_demo_system (
+    //input
+    .clk_sys_i(clk_sys),
+    .rst_sys_ni(rst_sys_n),
+    .gp_i(SW),
+    .uart_rx_i(UART_RX),
+
+    //output
+    .gp_o(LED),
+    .pwm_o(RGB_LED),
+    .uart_tx_o(UART_TX),
+
+    .spi_rx_i(1'b0),
+    .spi_tx_o(),
+    .spi_sck_o()
+  );
+
+  // Generating the system clock and reset for the FPGA.
+  clkgen_xil7series clkgen(
+    .IO_CLK,
+    .IO_RST_N,
+    .clk_sys,
+    .rst_sys_n
+  );
+
+endmodule

--- a/rtl/fpga/top_cw312a35.sv
+++ b/rtl/fpga/top_cw312a35.sv
@@ -5,34 +5,41 @@
 // This is the top level SystemVerilog file that connects the IO on the board to the Ibex Demo System.
 module top_cw312a35 (
   // These inputs are defined in data/pins_cw305.xdc
-  input               IO_CLK,
-  input               IO_RST_N,
-  input  [ 1:0]       SW,
-  output [ 2:0]       LED,
-  output [11:0]       RGB_LED,
-  input               UART_RX,
-  output              UART_TX
+  input  logic          IO_CLK,
+  input  logic          IO_RST_N,
+  input  logic          IO3,
+  output logic          IO4,
+  output logic [ 2:0]   LED,
+  input  logic          UART_RX,
+  output logic          UART_TX
 );
   parameter SRAMInitFile = "";
 
   logic clk_sys, rst_sys_n;
+  reg [24:0] clock_heartbeat;
+
+  assign LED[0] = clock_heartbeat[24];
+  assign LED[1] = ~UART_RX || ~UART_TX;
+  assign LED[2] = IO4;
+
+  always @(posedge clk_sys) clock_heartbeat <= clock_heartbeat +  25'd1;
 
   // Instantiating the Ibex Demo System.
   ibex_demo_system #(
-    .GpiWidth(3),
-    .GpoWidth(3),
-    .PwmWidth(12),
+    .GpiWidth(1),
+    .GpoWidth(1),
+    .PwmWidth(1),
     .SRAMInitFile(SRAMInitFile)
   ) u_ibex_demo_system (
     //input
     .clk_sys_i(clk_sys),
     .rst_sys_ni(rst_sys_n),
-    .gp_i({2'b00, SW}),
+    .gp_i(IO3),
     .uart_rx_i(UART_RX),
 
     //output
-    .gp_o(LED),
-    .pwm_o(RGB_LED),
+    .gp_o(IO4),
+    .pwm_o(),
     .uart_tx_o(UART_TX),
 
     .spi_rx_i(1'b0),

--- a/rtl/fpga/top_cw312a35.sv
+++ b/rtl/fpga/top_cw312a35.sv
@@ -1,0 +1,51 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This is the top level SystemVerilog file that connects the IO on the board to the Ibex Demo System.
+module top_cw312a35 (
+  // These inputs are defined in data/pins_cw305.xdc
+  input               IO_CLK,
+  input               IO_RST_N,
+  input  [ 1:0]       SW,
+  output [ 2:0]       LED,
+  output [11:0]       RGB_LED,
+  input               UART_RX,
+  output              UART_TX
+);
+  parameter SRAMInitFile = "";
+
+  logic clk_sys, rst_sys_n;
+
+  // Instantiating the Ibex Demo System.
+  ibex_demo_system #(
+    .GpiWidth(3),
+    .GpoWidth(3),
+    .PwmWidth(12),
+    .SRAMInitFile(SRAMInitFile)
+  ) u_ibex_demo_system (
+    //input
+    .clk_sys_i(clk_sys),
+    .rst_sys_ni(rst_sys_n),
+    .gp_i({2'b00, SW}),
+    .uart_rx_i(UART_RX),
+
+    //output
+    .gp_o(LED),
+    .pwm_o(RGB_LED),
+    .uart_tx_o(UART_TX),
+
+    .spi_rx_i(1'b0),
+    .spi_tx_o(),
+    .spi_sck_o()
+  );
+
+  // Generating the system clock and reset for the FPGA.
+  clkgen_xil7series clkgen(
+    .IO_CLK,
+    .IO_RST_N,
+    .clk_sys,
+    .rst_sys_n
+  );
+
+endmodule

--- a/sw/demo/CMakeLists.txt
+++ b/sw/demo/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_subdirectory(hello_world)
 add_subdirectory(lcd_st7735)
+add_subdirectory(simpleserial-aes)
+add_subdirectory(basic-passwdcheck)

--- a/sw/demo/basic-passwdcheck/CMakeLists.txt
+++ b/sw/demo/basic-passwdcheck/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_definitions(-DSS_VER=1 -DHAL_TYPE=HAL_ibex)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/newae/crypto)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/newae/hal)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/newae/simpleserial)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../common)
+
+
+add_prog(basic-passwdcheck ${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/newae/basic-passwdcheck/basic-passwdcheck.c)
+
+target_link_libraries(basic-passwdcheck simpleserial)
+

--- a/sw/demo/basic-passwdcheck/README
+++ b/sw/demo/basic-passwdcheck/README
@@ -1,0 +1,23 @@
+ChipWhisperer basic-passwdcheck application, intended to be run on a
+ChipWhisperer FPGA target (synth_cw305 or synth_cw312a35 targets).
+
+This can then be used with NewAE's "Power Analysis for Password Bypass" 
+notebook
+(https://github.com/newaetech/chipwhisperer-jupyter/tree/master/courses/sca101/),
+with modifications to the target clock and baud rate:
+    scope.clock.adc_mul = 1 # if using CW-Husky
+    scope.clock.adc_src = 'clkgen_x1' # if using CW-lite/pro
+    scope.clock.clkgen_freq = 100e6
+    target.baud = 115200
+
+Note that the password bypass attack will not work well on the CW305 target
+since that target lacks a method to reset the Ibex processor from the host PC
+(top_cw305.sv could be modified to achieve this). However it will work on the
+CW312-A35 target.
+
+Note that this application (and many others!) can also be built in the
+ChipWhisperer repository: 
+    https://github.com/newaetech/chipwhisperer/tree/develop/hardware/victims/firmware/basic-passwdcheck/
+using:
+    make PLATFORM=CW305_IBEX CRYPTO_TARGET=NONE
+

--- a/sw/demo/simpleserial-aes/CMakeLists.txt
+++ b/sw/demo/simpleserial-aes/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_definitions(-DTINYAES128C -DSS_VER=1 -DHAL_TYPE=HAL_ibex)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/newae/crypto)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/newae/hal)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/newae/simpleserial)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/newae/crypto/tiny-AES128-C)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../common)
+
+add_library(simpleserial
+${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/newae/simpleserial/simpleserial.c
+${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/newae/hal/ibex/ibex_hal.c
+)
+
+add_library(tiny-AES128
+${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/newae/crypto/aes-independant.c
+${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/newae/crypto/tiny-AES128-C/aes.c
+)
+
+add_prog(simpleserial-aes ${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/newae/simpleserial-aes/simpleserial-aes.c)
+
+target_link_libraries(simpleserial-aes simpleserial tiny-AES128)
+

--- a/sw/demo/simpleserial-aes/README
+++ b/sw/demo/simpleserial-aes/README
@@ -1,0 +1,18 @@
+ChipWhisperer simpleserial-aes application, intended to be run on a
+ChipWhisperer FPGA target (synth_cw305 or synth_cw312a35 targets).
+
+This can then be used with any of the NewAE Jupyter-based courses
+(https://github.com/newaetech/chipwhisperer-jupyter/tree/master/courses)
+which use simpleserial-aes, with modifications to the target clock and baud
+rate:
+    scope.clock.adc_mul = 1 # if using CW-Husky
+    scope.clock.adc_src = 'clkgen_x1' # if using CW-lite/pro
+    scope.clock.clkgen_freq = 100e6
+    target.baud = 115200
+
+Note that this application (and many others!) can also be built in the
+ChipWhisperer repository: 
+    https://github.com/newaetech/chipwhisperer/tree/develop/hardware/victims/firmware/simpleserial-aes
+using:
+    make PLATFORM=CW305_IBEX CRYPTO_TARGET=TINYAES128C
+

--- a/vendor/newae/basic-passwdcheck/basic-passwdcheck.c
+++ b/vendor/newae/basic-passwdcheck/basic-passwdcheck.c
@@ -1,0 +1,132 @@
+/*
+    This file is part of the ChipWhisperer Example Targets
+    Copyright (C) 2012-2015 NewAE Technology Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "hal.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#define IDLE 0
+#define KEY 1
+#define PLAIN 2
+
+#define BUFLEN 64
+
+uint8_t memory[BUFLEN];
+uint8_t tmp[BUFLEN];
+char asciibuf[BUFLEN];
+uint8_t pt[16];
+
+static void delay_2_ms(void);
+
+
+void my_puts(char *c)
+{
+  do {
+    putch(*c);
+
+  } while (*++c);
+}
+
+static void delay_2_ms()
+{
+  for (volatile unsigned int i=0; i < 0xfff; i++ ){
+    ;
+  }
+}
+
+void my_read(char *buf, int len)
+{
+  for(int i = 0; i < len; i++) {
+    while (buf[i] = getch(), buf[i] == '\0');
+
+    if (buf[i] == '\n') {
+      buf[i] = '\0';
+      return;
+    }
+  }
+  buf[len - 1] = '\0';
+}
+
+int main(void)
+  {
+    platform_init();
+  init_uart();
+  trigger_setup();
+
+    char passwd[32];
+    char correct_passwd[] = "h0px3";
+
+  while(1){
+
+        my_puts("*****Safe-o-matic 3000 Booting...\n");
+        //Print some fancy-sounding stuff so that attackers
+        //will get scared and leave us alone
+        my_puts("Aligning bits........[DONE]\n");
+        delay_2_ms();
+        my_puts("Checking Cesium RNG..[DONE]\n");
+        delay_2_ms();
+        my_puts("Masquerading flash...[DONE]\n");
+        delay_2_ms();
+        my_puts("Decrypting database..[DONE]\n");
+        delay_2_ms();
+        my_puts("\n\n");
+
+        //Give them one last warning
+        my_puts("WARNING: UNAUTHORIZED ACCESS WILL BE PUNISHED\n");
+
+        trigger_low();
+
+        //Get password
+        my_puts("Please enter password to continue: ");
+        my_read(passwd, 32);
+
+        uint8_t passbad = 0;
+
+        trigger_high();
+
+        for(uint8_t i = 0; i < sizeof(correct_passwd); i++){
+            if (correct_passwd[i] != passwd[i]){
+                passbad = 1;
+                break;
+            }
+        }
+
+        if (passbad){
+            //Stop them fancy timing attacks
+             int wait = 1;
+            for(volatile int i = 0; i < wait; i++){
+                ;
+            }
+            delay_2_ms();
+            delay_2_ms();
+            my_puts("PASSWORD FAIL\n");
+            led_error(1);
+        } else {
+            my_puts("Access granted, Welcome!\n");
+            led_ok(1);
+        }
+
+        //All done;
+        while(1);
+  }
+
+  return 1;
+  }
+
+

--- a/vendor/newae/crypto/aes-independant.c
+++ b/vendor/newae/crypto/aes-independant.c
@@ -1,0 +1,458 @@
+/*
+    This file is part of the AESExplorer Example Targets
+    Copyright (C) 2012 Colin O'Flynn <coflynn@newae.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "aes-independant.h"
+#include "hal.h"
+
+#if HWCRYPTO
+
+void aes_indep_init(void)
+{
+    HW_AES128_Init();
+}
+
+void aes_indep_key(uint8_t * key)
+{
+    HW_AES128_LoadKey(key);
+}
+
+void aes_indep_enc_pretrigger(uint8_t * pt)
+{
+    HW_AES128_Enc_pretrigger(pt);
+}
+
+void aes_indep_enc_posttrigger(uint8_t * pt)
+{
+    HW_AES128_Enc_posttrigger(pt);
+}
+
+void aes_indep_enc(uint8_t * pt)
+{
+    HW_AES128_Enc(pt);
+}
+
+void aes_indep_mask(uint8_t * m, uint8_t len)
+{
+}
+
+#elif defined(AVRCRYPTOLIB)
+#include "aes128_enc.h"
+#include "aes_keyschedule.h"
+
+aes128_ctx_t ctx;
+
+void aes_indep_init(void)
+{
+	;
+}
+
+void aes_indep_key(uint8_t * key)
+{
+	aes128_init(key, &ctx);
+}
+
+void aes_indep_enc(uint8_t * pt)
+{
+	aes128_enc(pt, &ctx); /* encrypting the data block */
+}
+
+void aes_indep_enc_pretrigger(uint8_t * pt)
+{
+    ;
+}
+
+void aes_indep_enc_posttrigger(uint8_t * pt)
+{
+    ;
+}
+
+void aes_indep_mask(uint8_t * m, uint8_t len)
+{
+}
+
+#elif defined(SIMPLEAES)
+
+uint8_t enckey[16];
+
+void aes_indep_init(void)
+{
+	;
+}
+
+void aes_indep_key(uint8_t * key)
+{
+	for(uint8_t i=0; i < 16; i++){
+		enckey[i] = key[i];
+	}
+}
+
+void aes_indep_enc(uint8_t * pt)
+{
+	uint8_t * result = aes(pt, enckey);
+	for(uint8_t i=0; i < 16; i++){
+		pt[i] = result[i];
+	}
+}
+
+void aes_indep_enc_pretrigger(uint8_t * pt)
+{
+    ;
+}
+
+void aes_indep_enc_posttrigger(uint8_t * pt)
+{
+    ;
+}
+
+void aes_indep_mask(uint8_t * m, uint8_t len)
+{
+}
+
+#elif defined(DPAV4)
+
+#include "aes.h"
+#include "aes_enc.h"
+
+/*  This is the AES RSM 256 encryption function that call the generic AES RSM encryption core*/
+void aes256_enc(uint8_t* j, void* buffer, aes256_ctx_t* ctx,uint8_t rng){
+	aes_encrypt_core(j,buffer, (aes_genctx_t*)ctx, 14,(uint8_t)rng);
+}
+
+aes256_ctx_t ctx;
+
+void aes_indep_init(void)
+{
+    ;
+}
+
+void aes_indep_key(uint8_t * key)
+{
+	aes256_init(key, &ctx);
+}
+
+void aes_indep_enc(uint8_t * pt)
+{
+	static uint8_t j[0];
+
+	//Encryption with trigger enabled
+	aes256_enc(j, pt, &ctx, 1);
+}
+
+void aes_indep_enc_pretrigger(uint8_t * pt)
+{
+    ;
+}
+
+void aes_indep_enc_posttrigger(uint8_t * pt)
+{
+    ;
+}
+
+void aes_indep_mask(uint8_t * m, uint8_t len)
+{
+}
+
+#elif defined(TINYAES128C)
+
+#include "aes.h"
+
+uint8_t enckey[16];
+
+void aes_indep_init(void)
+{
+	;
+}
+
+void aes_indep_key(uint8_t * key)
+{
+    AES128_ECB_indp_setkey(key);
+}
+
+void aes_indep_enc(uint8_t * pt)
+{
+	AES128_ECB_indp_crypto(pt);
+}
+
+void aes_indep_enc_pretrigger(uint8_t * pt)
+{
+    ;
+}
+
+void aes_indep_enc_posttrigger(uint8_t * pt)
+{
+    ;
+}
+
+void aes_indep_mask(uint8_t * m, uint8_t len)
+{
+}
+
+#elif defined(MBEDTLS)
+#include "mbedtls/aes.h"
+
+mbedtls_aes_context ctx;
+
+void aes_indep_init(void)
+{
+	mbedtls_aes_init(&ctx);
+}
+
+void aes_indep_enc_pretrigger(uint8_t * pt)
+{
+    ;
+}
+
+void aes_indep_enc_posttrigger(uint8_t * pt)
+{
+    ;
+}
+
+void aes_indep_key(uint8_t * key)
+{
+	mbedtls_aes_setkey_enc(&ctx, key, 128);
+}
+
+void aes_indep_enc(uint8_t * pt)
+{
+	mbedtls_aes_crypt_ecb(&ctx, MBEDTLS_AES_ENCRYPT, pt, pt); /* encrypting the data block */
+}
+
+void aes_indep_mask(uint8_t * m, uint8_t len)
+{
+}
+
+#elif defined(MASKEDAES)
+
+#if defined(ANSSI_AVR)
+
+#include "aesTables.h"
+#include "maskedAES128enc.h"
+
+void aes_indep_init(void)
+{
+}
+
+void aes_indep_key(uint8_t * key)
+{
+  int i;
+  for (i = 0; i < AESKeySize; i++)
+    secret[i] = key[i];
+}
+
+void aes_indep_enc(uint8_t * pt)
+{
+  asm_maskedAES128enc();
+}
+
+void aes_indep_enc_pretrigger(uint8_t * pt)
+{
+  int i;
+  for (i = 0; i < AESInputSize; i++)
+    input[i] = pt[i];
+}
+
+void aes_indep_enc_posttrigger(uint8_t * pt)
+{
+    int i;
+  for (i = 0; i < AESOutputSize; i++)
+    pt[i] = input[i];
+}
+
+void aes_indep_mask(uint8_t * m, uint8_t len)
+{
+  int i;
+  for (i = 0; i < AESMaskSize; i++)
+    mask[i] = m[i];
+}
+
+#elif defined(ANSSI_CM4)
+
+#include "platform.h"
+#include "string.h"
+#include "aes.h"
+
+#ifndef NULL
+#define NULL 0
+#endif
+
+#define AESKeySize 16
+#define AESMaskSize 19
+#define AESBlockSize 16
+
+STRUCT_AES aes_ctx;
+uint8_t key_mask[AESMaskSize];
+uint8_t aes_mask[AESMaskSize];
+uint8_t temp_key[AESKeySize];
+uint8_t mask_modes;
+
+void aes_indep_init(void)
+{
+  local_memset(&aes_ctx, 0, sizeof(aes_ctx));
+  mask_modes = 0;
+}
+
+void aes_indep_key(uint8_t* key)
+{
+#ifdef TRIG_BEFORE_KS
+  int i;
+  for (i = 0; i < AESKeySize; i++)
+    temp_key[i] = key[i];
+#else
+  aes(MODE_KEYINIT | mask_modes, &aes_ctx, key,
+      NULL /* plaintext */, NULL /* encrypted text */,
+      aes_mask, key_mask);
+#endif
+}
+
+void aes_indep_enc_pretrigger(uint8_t * pt)
+{
+}
+
+void aes_indep_enc_posttrigger(uint8_t * pt)
+{
+}
+
+void aes_indep_enc(uint8_t* pt)
+{
+#ifdef TRIG_BEFORE_KS
+  aes(MODE_KEYINIT | MODE_AESINIT_ENC | MODE_ENC | mask_modes,
+      &aes_ctx, temp_key,
+      pt /* plaintext */, pt /* encrypted text */,
+      aes_mask, key_mask);
+#else
+  aes(MODE_AESINIT_ENC | MODE_ENC | mask_modes, &aes_ctx, NULL /* key */,
+      pt /* plaintext */, pt /* encryted text */,
+      aes_mask, key_mask);
+#endif
+}
+
+void aes_indep_mask(uint8_t* m, uint8_t len)
+{
+  int i;
+  if (len >= AESMaskSize) {
+    for (i = 0; i < AESMaskSize; i++)
+      key_mask[i] = m[i];
+    mask_modes |= MODE_RANDOM_KEY_EXT;
+  } else {
+    mask_modes &= ~MODE_RANDOM_KEY_EXT;
+  }
+
+  if (len == (2 * AESMaskSize)) {
+    for (i = 0; i < AESMaskSize; i++)
+      aes_mask[i] = m[i + AESMaskSize];
+    mask_modes |= MODE_RANDOM_AES_EXT;
+  } else {
+    mask_modes &= ~MODE_RANDOM_AES_EXT;
+  }
+}
+
+#elif defined(RIOUBSAES)
+
+#include "secure_aes_pbs.h"
+
+uint8_t encKey[16];
+
+bitslice_t get_random_bitslice(void)
+{
+  return get_rand();
+}
+
+void aes_indep_init(void)
+{
+}
+
+void aes_indep_key(uint8_t * key)
+{
+  for (uint8_t i = 0; i < 16; i++) {
+    encKey[i] = key[i];
+  }
+}
+
+void aes_indep_enc_pretrigger(uint8_t * pt)
+{
+}
+
+void aes_indep_enc_posttrigger(uint8_t * pt)
+{
+}
+
+void aes_indep_enc(uint8_t * pt)
+{
+  sec_aes128_enc_packed_bitslice_wrapper(pt, pt, encKey);
+}
+
+void aes_indep_mask(uint8_t * m, uint8_t len)
+{
+}
+
+#elif defined(KNARFRANKBSAES)
+
+#include "masked_combined.h"
+
+uint8_t encKey[16];
+
+int rand(void)
+{
+  return get_rand();
+}
+
+void aes_indep_init(void)
+{
+}
+
+void aes_indep_key(uint8_t * key)
+{
+  for (uint8_t i = 0; i < 16; i++) {
+    encKey[i] = key[i];
+  }
+}
+
+void aes_indep_enc_pretrigger(uint8_t * pt)
+{
+}
+
+void aes_indep_enc_posttrigger(uint8_t * pt)
+{
+}
+
+void aes_indep_enc(uint8_t * pt)
+{
+  uint8_t result[16];
+  Encrypt(result, pt, encKey);
+  for (uint8_t i = 0; i < 16; i++) {
+    pt[i] = result[i];
+  }
+}
+
+void aes_indep_mask(uint8_t * m, uint8_t len)
+{
+}
+
+#else
+
+#error "Unsupported MASKEDAES implementation"
+
+#endif // MASKEDAES
+
+#else
+
+#error "No Crypto Lib Defined?"
+
+#endif
+
+

--- a/vendor/newae/crypto/aes-independant.h
+++ b/vendor/newae/crypto/aes-independant.h
@@ -1,0 +1,51 @@
+/*
+    This file is part of the ChipWhisperer Example Targets
+    Copyright (C) 2012-2015 NewAE Technology Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#ifndef AES_INDEPENDANT_
+#define AES_INDEPENDANT_
+
+#include <stdint.h>
+
+#ifdef DPAV4
+#define KEY_LENGTH 32
+//DPAv4 Default Key
+#define DEFAULT_KEY 0x6c,0xec,0xc6,0x7f,0x28,0x7d,0x08,0x3d, \
+		0xeb,0x87,0x66,0xf0,0x73,0x8b,0x36,0xcf, \
+		0x16,0x4e,0xd9,0xb2,0x46,0x95,0x10,0x90, \
+		0x86,0x9d,0x08,0x28,0x5d,0x2e,0x19,0x3b
+
+//Some Other Key
+/*
+#define DEFAULT_KEY 0x1f,0x3e,0xa0,0x47,0x76,0x30,0xce,0x21, \
+        0xa2,0xce,0x33,0x4a,0xa7,0x46,0xc2,0xcd, \
+        0xc7,0x82,0xdc,0x4c,0x09,0x8c,0x66,0xcb, \
+        0xd9,0xcd,0x27,0xd8,0x25,0x68,0x2c,0x81
+*/
+
+#else
+#define KEY_LENGTH 16
+#define DEFAULT_KEY 0x2b,0x7e,0x15,0x16,0x28,0xae,0xd2,0xa6,0xab,0xf7,0x15,0x88,0x09,0xcf,0x4f,0x3c
+#endif
+
+void aes_indep_init(void);
+void aes_indep_key(uint8_t * key);
+void aes_indep_enc(uint8_t * pt);
+void aes_indep_enc_pretrigger(uint8_t * pt);
+void aes_indep_enc_posttrigger(uint8_t * pt);
+void aes_indep_mask(uint8_t * m, uint8_t len);
+
+#endif

--- a/vendor/newae/crypto/tiny-AES128-C/aes.c
+++ b/vendor/newae/crypto/tiny-AES128-C/aes.c
@@ -1,0 +1,548 @@
+/* This AES-128 comes from https://github.com/kokke/tiny-AES128-C which is released into public domain */
+
+/*
+
+This is an implementation of the AES128 algorithm, specifically ECB and CBC mode.
+
+The implementation is verified against the test vectors in:
+  National Institute of Standards and Technology Special Publication 800-38A 2001 ED
+
+ECB-AES128
+----------
+
+  plain-text:
+    6bc1bee22e409f96e93d7e117393172a
+    ae2d8a571e03ac9c9eb76fac45af8e51
+    30c81c46a35ce411e5fbc1191a0a52ef
+    f69f2445df4f9b17ad2b417be66c3710
+
+  key:
+    2b7e151628aed2a6abf7158809cf4f3c
+
+  resulting cipher
+    3ad77bb40d7a3660a89ecaf32466ef97 
+    f5d3d58503b9699de785895a96fdbaaf 
+    43b1cd7f598ece23881b00e3ed030688 
+    7b0c785e27e8ad3f8223207104725dd4 
+
+
+NOTE:   String length must be evenly divisible by 16byte (str_len % 16 == 0)
+        You should pad the end of the string with zeros if this is not the case.
+
+*/
+
+
+/*****************************************************************************/
+/* Includes:                                                                 */
+/*****************************************************************************/
+#include <stdint.h>
+#include <string.h> // CBC mode, for memset
+#include "aes.h"
+
+
+/*****************************************************************************/
+/* Defines:                                                                  */
+/*****************************************************************************/
+// The number of columns comprising a state in AES. This is a constant in AES. Value=4
+#define Nb 4
+// The number of 32 bit words in a key.
+#define Nk 4
+// Key length in bytes [128 bit]
+#define KEYLEN 16
+// The number of rounds in AES Cipher.
+#define Nr 10
+
+// jcallan@github points out that declaring Multiply as a function 
+// reduces code size considerably with the Keil ARM compiler.
+// See this link for more information: https://github.com/kokke/tiny-AES128-C/pull/3
+#ifndef MULTIPLY_AS_A_FUNCTION
+  #define MULTIPLY_AS_A_FUNCTION 0
+#endif
+
+
+/*****************************************************************************/
+/* Private variables:                                                        */
+/*****************************************************************************/
+// state - array holding the intermediate results during decryption.
+typedef uint8_t state_t[4][4];
+static state_t* state;
+
+// The array that stores the round keys.
+static uint8_t RoundKey[176];
+
+static uint8_t input_save[16];
+
+// The Key input to the AES Program
+static uint8_t* Key;
+
+// The lookup-tables are marked const so they can be placed in read-only storage instead of RAM
+// The numbers below can be computed dynamically trading ROM for RAM - 
+// This can be useful in (embedded) bootloader applications, where ROM is often limited.
+AES_CONST_VAR uint8_t sbox[256] =   {
+  //0     1    2      3     4    5     6     7      8    9     A      B    C     D     E     F
+  0x63, 0x7c, 0x77, 0x7b, 0xf2, 0x6b, 0x6f, 0xc5, 0x30, 0x01, 0x67, 0x2b, 0xfe, 0xd7, 0xab, 0x76,
+  0xca, 0x82, 0xc9, 0x7d, 0xfa, 0x59, 0x47, 0xf0, 0xad, 0xd4, 0xa2, 0xaf, 0x9c, 0xa4, 0x72, 0xc0,
+  0xb7, 0xfd, 0x93, 0x26, 0x36, 0x3f, 0xf7, 0xcc, 0x34, 0xa5, 0xe5, 0xf1, 0x71, 0xd8, 0x31, 0x15,
+  0x04, 0xc7, 0x23, 0xc3, 0x18, 0x96, 0x05, 0x9a, 0x07, 0x12, 0x80, 0xe2, 0xeb, 0x27, 0xb2, 0x75,
+  0x09, 0x83, 0x2c, 0x1a, 0x1b, 0x6e, 0x5a, 0xa0, 0x52, 0x3b, 0xd6, 0xb3, 0x29, 0xe3, 0x2f, 0x84,
+  0x53, 0xd1, 0x00, 0xed, 0x20, 0xfc, 0xb1, 0x5b, 0x6a, 0xcb, 0xbe, 0x39, 0x4a, 0x4c, 0x58, 0xcf,
+  0xd0, 0xef, 0xaa, 0xfb, 0x43, 0x4d, 0x33, 0x85, 0x45, 0xf9, 0x02, 0x7f, 0x50, 0x3c, 0x9f, 0xa8,
+  0x51, 0xa3, 0x40, 0x8f, 0x92, 0x9d, 0x38, 0xf5, 0xbc, 0xb6, 0xda, 0x21, 0x10, 0xff, 0xf3, 0xd2,
+  0xcd, 0x0c, 0x13, 0xec, 0x5f, 0x97, 0x44, 0x17, 0xc4, 0xa7, 0x7e, 0x3d, 0x64, 0x5d, 0x19, 0x73,
+  0x60, 0x81, 0x4f, 0xdc, 0x22, 0x2a, 0x90, 0x88, 0x46, 0xee, 0xb8, 0x14, 0xde, 0x5e, 0x0b, 0xdb,
+  0xe0, 0x32, 0x3a, 0x0a, 0x49, 0x06, 0x24, 0x5c, 0xc2, 0xd3, 0xac, 0x62, 0x91, 0x95, 0xe4, 0x79,
+  0xe7, 0xc8, 0x37, 0x6d, 0x8d, 0xd5, 0x4e, 0xa9, 0x6c, 0x56, 0xf4, 0xea, 0x65, 0x7a, 0xae, 0x08,
+  0xba, 0x78, 0x25, 0x2e, 0x1c, 0xa6, 0xb4, 0xc6, 0xe8, 0xdd, 0x74, 0x1f, 0x4b, 0xbd, 0x8b, 0x8a,
+  0x70, 0x3e, 0xb5, 0x66, 0x48, 0x03, 0xf6, 0x0e, 0x61, 0x35, 0x57, 0xb9, 0x86, 0xc1, 0x1d, 0x9e,
+  0xe1, 0xf8, 0x98, 0x11, 0x69, 0xd9, 0x8e, 0x94, 0x9b, 0x1e, 0x87, 0xe9, 0xce, 0x55, 0x28, 0xdf,
+  0x8c, 0xa1, 0x89, 0x0d, 0xbf, 0xe6, 0x42, 0x68, 0x41, 0x99, 0x2d, 0x0f, 0xb0, 0x54, 0xbb, 0x16 };
+
+AES_CONST_VAR uint8_t rsbox[256] =
+{ 0x52, 0x09, 0x6a, 0xd5, 0x30, 0x36, 0xa5, 0x38, 0xbf, 0x40, 0xa3, 0x9e, 0x81, 0xf3, 0xd7, 0xfb,
+  0x7c, 0xe3, 0x39, 0x82, 0x9b, 0x2f, 0xff, 0x87, 0x34, 0x8e, 0x43, 0x44, 0xc4, 0xde, 0xe9, 0xcb,
+  0x54, 0x7b, 0x94, 0x32, 0xa6, 0xc2, 0x23, 0x3d, 0xee, 0x4c, 0x95, 0x0b, 0x42, 0xfa, 0xc3, 0x4e,
+  0x08, 0x2e, 0xa1, 0x66, 0x28, 0xd9, 0x24, 0xb2, 0x76, 0x5b, 0xa2, 0x49, 0x6d, 0x8b, 0xd1, 0x25,
+  0x72, 0xf8, 0xf6, 0x64, 0x86, 0x68, 0x98, 0x16, 0xd4, 0xa4, 0x5c, 0xcc, 0x5d, 0x65, 0xb6, 0x92,
+  0x6c, 0x70, 0x48, 0x50, 0xfd, 0xed, 0xb9, 0xda, 0x5e, 0x15, 0x46, 0x57, 0xa7, 0x8d, 0x9d, 0x84,
+  0x90, 0xd8, 0xab, 0x00, 0x8c, 0xbc, 0xd3, 0x0a, 0xf7, 0xe4, 0x58, 0x05, 0xb8, 0xb3, 0x45, 0x06,
+  0xd0, 0x2c, 0x1e, 0x8f, 0xca, 0x3f, 0x0f, 0x02, 0xc1, 0xaf, 0xbd, 0x03, 0x01, 0x13, 0x8a, 0x6b,
+  0x3a, 0x91, 0x11, 0x41, 0x4f, 0x67, 0xdc, 0xea, 0x97, 0xf2, 0xcf, 0xce, 0xf0, 0xb4, 0xe6, 0x73,
+  0x96, 0xac, 0x74, 0x22, 0xe7, 0xad, 0x35, 0x85, 0xe2, 0xf9, 0x37, 0xe8, 0x1c, 0x75, 0xdf, 0x6e,
+  0x47, 0xf1, 0x1a, 0x71, 0x1d, 0x29, 0xc5, 0x89, 0x6f, 0xb7, 0x62, 0x0e, 0xaa, 0x18, 0xbe, 0x1b,
+  0xfc, 0x56, 0x3e, 0x4b, 0xc6, 0xd2, 0x79, 0x20, 0x9a, 0xdb, 0xc0, 0xfe, 0x78, 0xcd, 0x5a, 0xf4,
+  0x1f, 0xdd, 0xa8, 0x33, 0x88, 0x07, 0xc7, 0x31, 0xb1, 0x12, 0x10, 0x59, 0x27, 0x80, 0xec, 0x5f,
+  0x60, 0x51, 0x7f, 0xa9, 0x19, 0xb5, 0x4a, 0x0d, 0x2d, 0xe5, 0x7a, 0x9f, 0x93, 0xc9, 0x9c, 0xef,
+  0xa0, 0xe0, 0x3b, 0x4d, 0xae, 0x2a, 0xf5, 0xb0, 0xc8, 0xeb, 0xbb, 0x3c, 0x83, 0x53, 0x99, 0x61,
+  0x17, 0x2b, 0x04, 0x7e, 0xba, 0x77, 0xd6, 0x26, 0xe1, 0x69, 0x14, 0x63, 0x55, 0x21, 0x0c, 0x7d };
+
+
+// The round constant word array, Rcon[i], contains the values given by 
+// x to th e power (i-1) being powers of x (x is denoted as {02}) in the field GF(2^8)
+// Note that i starts at 1, not 0).
+AES_CONST_VAR uint8_t Rcon[11] = {
+  0x8d, 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36
+};
+
+
+/*****************************************************************************/
+/* Private functions:                                                        */
+/*****************************************************************************/
+static uint8_t getSBoxValue(uint8_t num)
+{
+  return sbox[num];
+}
+
+static uint8_t getSBoxInvert(uint8_t num)
+{
+  return rsbox[num];
+}
+
+// This function produces Nb(Nr+1) round keys. The round keys are used in each round to decrypt the states. 
+static void KeyExpansion(void)
+{
+  uint32_t i, j, k;
+  uint8_t tempa[4]; // Used for the column/row operations
+  
+  // The first round key is the key itself.
+  for(i = 0; i < Nk; ++i)
+  {
+    RoundKey[(i * 4) + 0] = Key[(i * 4) + 0];
+    RoundKey[(i * 4) + 1] = Key[(i * 4) + 1];
+    RoundKey[(i * 4) + 2] = Key[(i * 4) + 2];
+    RoundKey[(i * 4) + 3] = Key[(i * 4) + 3];
+  }
+
+  // All other round keys are found from the previous round keys.
+  for(; (i < (Nb * (Nr + 1))); ++i)
+  {
+    for(j = 0; j < 4; ++j)
+    {
+      tempa[j]=RoundKey[(i-1) * 4 + j];
+    }
+    if (i % Nk == 0)
+    {
+      // This function rotates the 4 bytes in a word to the left once.
+      // [a0,a1,a2,a3] becomes [a1,a2,a3,a0]
+
+      // Function RotWord()
+      {
+        k = tempa[0];
+        tempa[0] = tempa[1];
+        tempa[1] = tempa[2];
+        tempa[2] = tempa[3];
+        tempa[3] = k;
+      }
+
+      // SubWord() is a function that takes a four-byte input word and 
+      // applies the S-box to each of the four bytes to produce an output word.
+
+      // Function Subword()
+      {
+        tempa[0] = getSBoxValue(tempa[0]);
+        tempa[1] = getSBoxValue(tempa[1]);
+        tempa[2] = getSBoxValue(tempa[2]);
+        tempa[3] = getSBoxValue(tempa[3]);
+      }
+
+      tempa[0] =  tempa[0] ^ Rcon[i/Nk];
+    }
+    else if (Nk > 6 && i % Nk == 4)
+    {
+      // Function Subword()
+      {
+        tempa[0] = getSBoxValue(tempa[0]);
+        tempa[1] = getSBoxValue(tempa[1]);
+        tempa[2] = getSBoxValue(tempa[2]);
+        tempa[3] = getSBoxValue(tempa[3]);
+      }
+    }
+    RoundKey[i * 4 + 0] = RoundKey[(i - Nk) * 4 + 0] ^ tempa[0];
+    RoundKey[i * 4 + 1] = RoundKey[(i - Nk) * 4 + 1] ^ tempa[1];
+    RoundKey[i * 4 + 2] = RoundKey[(i - Nk) * 4 + 2] ^ tempa[2];
+    RoundKey[i * 4 + 3] = RoundKey[(i - Nk) * 4 + 3] ^ tempa[3];
+  }
+}
+
+// This function adds the round key to state.
+// The round key is added to the state by an XOR function.
+static void AddRoundKey(uint8_t round)
+{
+  uint8_t i,j;
+  for(i=0;i<4;++i)
+  {
+    for(j = 0; j < 4; ++j)
+    {
+      (*state)[i][j] ^= RoundKey[round * Nb * 4 + i * Nb + j];
+    }
+  }
+}
+
+// The SubBytes Function Substitutes the values in the
+// state matrix with values in an S-box.
+static void SubBytes(void)
+{
+  uint8_t i, j;
+  for(i = 0; i < 4; ++i)
+  {
+    for(j = 0; j < 4; ++j)
+    {
+      #ifdef JITTER_2
+      if (input_save[4*i+j] & 0x01) {
+        volatile int i = 1;
+        i+=1;
+      }
+      #endif
+      #ifdef JITTER_2
+      if (input_save[4*i+j] & 0x02) {
+        volatile int i = 1;
+        i+=1;
+      }
+      #endif
+      (*state)[j][i] = getSBoxValue((*state)[j][i]);
+    }
+  }
+}
+
+// The ShiftRows() function shifts the rows in the state to the left.
+// Each row is shifted with different offset.
+// Offset = Row number. So the first row is not shifted.
+static void ShiftRows(void)
+{
+  uint8_t temp;
+
+  // Rotate first row 1 columns to left  
+      #ifdef JITTER_2
+      if (input_save[1] & 0x01) {
+        volatile int i = 0;
+        i += 1;
+      }
+      if (input_save[2] & 0x02) {
+        volatile int i = 0;
+        i += 1;
+      }
+      #endif
+  #ifdef JITTER_2
+  #endif
+  temp           = (*state)[0][1];
+  (*state)[0][1] = (*state)[1][1];
+  (*state)[1][1] = (*state)[2][1];
+  (*state)[2][1] = (*state)[3][1];
+  (*state)[3][1] = temp;
+
+  // Rotate second row 2 columns to left  
+      #ifdef JITTER_2
+      if (input_save[4] & 0x01) {
+        volatile int i = 0;
+        i += 1;
+      }
+      if (input_save[10] & 0x02) {
+        volatile int i = 0;
+        i += 1;
+      }
+      #endif
+  #ifdef JITTER_2
+  #endif
+  temp           = (*state)[0][2];
+  (*state)[0][2] = (*state)[2][2];
+  (*state)[2][2] = temp;
+  // Rotate second row 2 columns to left  
+  #ifdef JITTER_2
+  #endif
+      #ifdef JITTER_2
+      if (input_save[5] & 0x01) {
+        volatile int i = 0;
+        i += 1;
+      }
+      if (input_save[8] & 0x02) {
+        volatile int i = 0;
+        i += 1;
+      }
+      #endif
+
+  temp       = (*state)[1][2];
+  (*state)[1][2] = (*state)[3][2];
+  (*state)[3][2] = temp;
+
+  // Rotate second row 2 columns to left  
+      #ifdef JITTER_2
+      if (input_save[0] & 0x01) {
+        volatile int i = 0;
+        i += 1;
+      }
+      if (input_save[3] & 0x02) {
+        volatile int i = 0;
+        i += 1;
+      }
+      #endif
+  #ifdef JITTER_2
+  #endif
+  // Rotate third row 3 columns to left
+  temp       = (*state)[0][3];
+  (*state)[0][3] = (*state)[3][3];
+  (*state)[3][3] = (*state)[2][3];
+  (*state)[2][3] = (*state)[1][3];
+  (*state)[1][3] = temp;
+}
+
+static uint8_t xtime(uint8_t x)
+{
+  return ((x<<1) ^ (((x>>7) & 1) * 0x1b));
+}
+
+// MixColumns function mixes the columns of the state matrix
+static void MixColumns(void)
+{
+  uint8_t i;
+  uint8_t Tmp,Tm,t;
+  for(i = 0; i < 4; ++i)
+  {  
+      #ifdef JITTER_2
+      if (input_save[4*i] & 0x01) {
+        volatile int i = 0;
+        i += 1;
+      }
+      if (input_save[4*i] & 0x02) {
+        volatile int i = 0;
+        i += 1;
+      }
+      #endif
+    t   = (*state)[i][0];
+    Tmp = (*state)[i][0] ^ (*state)[i][1] ^ (*state)[i][2] ^ (*state)[i][3] ;
+    Tm  = (*state)[i][0] ^ (*state)[i][1] ; Tm = xtime(Tm);  (*state)[i][0] ^= Tm ^ Tmp ;
+    Tm  = (*state)[i][1] ^ (*state)[i][2] ; Tm = xtime(Tm);  (*state)[i][1] ^= Tm ^ Tmp ;
+    Tm  = (*state)[i][2] ^ (*state)[i][3] ; Tm = xtime(Tm);  (*state)[i][2] ^= Tm ^ Tmp ;
+    Tm  = (*state)[i][3] ^ t ;        Tm = xtime(Tm);  (*state)[i][3] ^= Tm ^ Tmp ;
+  }
+}
+
+// Multiply is used to multiply numbers in the field GF(2^8)
+#if MULTIPLY_AS_A_FUNCTION
+static uint8_t Multiply(uint8_t x, uint8_t y)
+{
+  return (((y & 1) * x) ^
+       ((y>>1 & 1) * xtime(x)) ^
+       ((y>>2 & 1) * xtime(xtime(x))) ^
+       ((y>>3 & 1) * xtime(xtime(xtime(x)))) ^
+       ((y>>4 & 1) * xtime(xtime(xtime(xtime(x))))));
+  }
+#else
+#define Multiply(x, y)                                \
+      (  ((y & 1) * x) ^                              \
+      ((y>>1 & 1) * xtime(x)) ^                       \
+      ((y>>2 & 1) * xtime(xtime(x))) ^                \
+      ((y>>3 & 1) * xtime(xtime(xtime(x)))) ^         \
+      ((y>>4 & 1) * xtime(xtime(xtime(xtime(x))))))   \
+
+#endif
+
+// MixColumns function mixes the columns of the state matrix.
+// The method used to multiply may be difficult to understand for the inexperienced.
+// Please use the references to gain more information.
+static void InvMixColumns(void)
+{
+  int i;
+  uint8_t a,b,c,d;
+  for(i=0;i<4;++i)
+  { 
+    a = (*state)[i][0];
+    b = (*state)[i][1];
+    c = (*state)[i][2];
+    d = (*state)[i][3];
+
+    (*state)[i][0] = Multiply(a, 0x0e) ^ Multiply(b, 0x0b) ^ Multiply(c, 0x0d) ^ Multiply(d, 0x09);
+    (*state)[i][1] = Multiply(a, 0x09) ^ Multiply(b, 0x0e) ^ Multiply(c, 0x0b) ^ Multiply(d, 0x0d);
+    (*state)[i][2] = Multiply(a, 0x0d) ^ Multiply(b, 0x09) ^ Multiply(c, 0x0e) ^ Multiply(d, 0x0b);
+    (*state)[i][3] = Multiply(a, 0x0b) ^ Multiply(b, 0x0d) ^ Multiply(c, 0x09) ^ Multiply(d, 0x0e);
+  }
+}
+
+
+// The SubBytes Function Substitutes the values in the
+// state matrix with values in an S-box.
+static void InvSubBytes(void)
+{
+  uint8_t i,j;
+  for(i=0;i<4;++i)
+  {
+    for(j=0;j<4;++j)
+    {
+      (*state)[j][i] = getSBoxInvert((*state)[j][i]);
+    }
+  }
+}
+
+static void InvShiftRows(void)
+{
+  uint8_t temp;
+
+  // Rotate first row 1 columns to right  
+  temp=(*state)[3][1];
+  (*state)[3][1]=(*state)[2][1];
+  (*state)[2][1]=(*state)[1][1];
+  (*state)[1][1]=(*state)[0][1];
+  (*state)[0][1]=temp;
+
+  // Rotate second row 2 columns to right 
+  temp=(*state)[0][2];
+  (*state)[0][2]=(*state)[2][2];
+  (*state)[2][2]=temp;
+
+  temp=(*state)[1][2];
+  (*state)[1][2]=(*state)[3][2];
+  (*state)[3][2]=temp;
+
+  // Rotate third row 3 columns to right
+  temp=(*state)[0][3];
+  (*state)[0][3]=(*state)[1][3];
+  (*state)[1][3]=(*state)[2][3];
+  (*state)[2][3]=(*state)[3][3];
+  (*state)[3][3]=temp;
+}
+
+
+// Cipher is the main function that encrypts the PlainText.
+static void Cipher(void)
+{
+  uint8_t round = 0;
+
+  // Add the First round key to the state before starting the rounds.
+  AddRoundKey(0); 
+  
+  // There will be Nr rounds.
+  // The first Nr-1 rounds are identical.
+  // These Nr-1 rounds are executed in the loop below.
+  for(round = 1; round < Nr; ++round)
+  {
+    SubBytes();
+    ShiftRows();
+    MixColumns();
+    AddRoundKey(round);
+  }
+  
+  // The last round is given below.
+  // The MixColumns function is not here in the last round.
+  SubBytes();
+  ShiftRows();
+  AddRoundKey(Nr);
+}
+
+static void InvCipher(void)
+{
+  uint8_t round=0;
+
+  // Add the First round key to the state before starting the rounds.
+  AddRoundKey(Nr); 
+
+  // There will be Nr rounds.
+  // The first Nr-1 rounds are identical.
+  // These Nr-1 rounds are executed in the loop below.
+  for(round=Nr-1;round>0;round--)
+  {
+    InvShiftRows();
+    InvSubBytes();
+    AddRoundKey(round);
+    InvMixColumns();
+  }
+  
+  // The last round is given below.
+  // The MixColumns function is not here in the last round.
+  InvShiftRows();
+  InvSubBytes();
+  AddRoundKey(0);
+}
+
+static void BlockCopy(uint8_t* output, const uint8_t* input)
+{
+  uint8_t i;
+  for (i=0;i<KEYLEN;++i)
+  {
+    output[i] = input[i];
+  }
+}
+
+
+
+/*****************************************************************************/
+/* Public functions:                                                         */
+/*****************************************************************************/
+
+void AES128_ECB_indp_setkey(uint8_t* key)
+{
+  Key = key;
+  KeyExpansion();
+}
+
+void AES128_ECB_indp_crypto(uint8_t* input)
+{
+  state = (state_t*)input;
+  BlockCopy(input_save, input);
+  Cipher();
+}
+
+void AES128_ECB_encrypt(uint8_t* input, uint8_t* key, uint8_t* output)
+{
+  // Copy input to output, and work in-memory on output
+  BlockCopy(output, input);
+  state = (state_t*)output;
+
+  Key = key;
+  KeyExpansion();
+
+  // The next function call encrypts the PlainText with the Key using AES algorithm.
+  Cipher();
+}
+
+void AES128_ECB_decrypt(uint8_t* input, uint8_t* key, uint8_t *output)
+{
+  // Copy input to output, and work in-memory on output
+  BlockCopy(output, input);
+  state = (state_t*)output;
+
+  // The KeyExpansion routine must be called before encryption.
+  Key = key;
+  KeyExpansion();
+
+  InvCipher();
+}
+
+

--- a/vendor/newae/crypto/tiny-AES128-C/aes.h
+++ b/vendor/newae/crypto/tiny-AES128-C/aes.h
@@ -1,0 +1,22 @@
+/* This AES-128 comes from https://github.com/kokke/tiny-AES128-C which is released into public domain */
+
+#ifndef _AES_H_
+#define _AES_H_
+
+#include <stdint.h>
+
+#ifndef AES_CONST_VAR
+//#define AES_CONST_VAR static const
+#define AES_CONST_VAR
+#endif
+
+
+void AES128_ECB_encrypt(uint8_t* input, uint8_t* key, uint8_t *output);
+void AES128_ECB_decrypt(uint8_t* input, uint8_t* key, uint8_t *output);
+
+void AES128_ECB_indp_setkey(uint8_t* key);
+void AES128_ECB_indp_crypto(uint8_t* input);
+
+
+
+#endif //_AES_H_

--- a/vendor/newae/hal/hal.h
+++ b/vendor/newae/hal/hal.h
@@ -1,0 +1,207 @@
+/*
+    This file is part of the ChipWhisperer Example Targets
+    Copyright (C) 2012-2015 NewAE Technology Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef HAL_H_
+#define HAL_H_
+
+#include <stdint.h>
+
+void platform_init(void);
+
+//PLATFORM Define Types
+#define CW301_AVR      1
+#define CW301_XMEGA    2
+#define CW303          3
+#define CW304          4
+#define CW308_MEGARF   8
+#define CW308_PIC24FJ  10
+#define CW308_SAM4L    11
+#define CW308_SI4010   12
+#define CW308_MPC5748G 13
+#define CW308_STM32F0  14
+#define CW308_STM32F1  15
+#define CW308_STM32F2  16
+#define CW308_STM32F3  17
+#define CW308_STM32F4  18
+#define CW308_CC2538   19
+#define CW308_K24F     20
+#define CW308_NRF52840 21
+#define CW308_AURIX    22
+#define CW308_SAML11   23
+#define CW308_EFM32TG11B 24
+#define CW308_K82F     25
+#define CW308_LPC55S6X 26
+#define CW308_PSOC62   27
+#define CW308_IMXRT1062 28
+#define CW308_FE310    29
+#define CW308_EFR32MG21A  30
+#define CW308_EFM32GG11  31
+#define CW308_STM32L5  32
+#define CW308_STM32L4  33
+#define CW308_RX65N  34
+#define CW308_MPC5676R 35
+#define CW308_NEORV32  36
+#define CW305_IBEX  37
+
+//HAL_TYPE Define Types
+#define HAL_avr      1
+#define HAL_xmega    2
+#define HAL_pic24f   3
+#define HAL_sam4l    4
+#define HAL_stm32f0  5
+#define HAL_stm32f1  6
+#define HAL_stm32f2  7
+#define HAL_stm32f3  8
+#define HAL_stm32f4  9
+#define HAL_cc2538   10
+#define HAL_k24f     11
+#define HAL_nrf52840 12
+#define HAL_stm32f0_nano 13
+#define HAL_aurix    14
+#define HAL_saml11   15
+#define HAL_efm32tg11b 16
+#define HAL_k82f     17
+#define HAL_lpc55s6x 18
+#define HAL_psoc62   19
+#define HAL_imxrt1062 20
+#define HAL_fe310    21
+#define HAL_efr32mg21a 22
+#define HAL_efm32gg11 23
+#define HAL_stm32l5 24
+#define HAL_stm32l4 25
+#define HAL_rx65n 26
+#define HAL_mpc5676r 27
+#define HAL_neorv32  28
+#define HAL_sam4s  29
+#define HAL_ibex  30
+
+#if HAL_TYPE == HAL_avr
+    #include <avr/io.h>
+    #include <util/delay.h>
+    #include "avr/avr_hal.h"
+#elif HAL_TYPE == HAL_xmega
+    #include <avr/io.h>
+    #include <util/delay.h>
+    #include "xmega/xmega_hal.h"
+    #include "xmega/avr_compiler.h"
+#elif HAL_TYPE == HAL_pic24f
+    #include <xc.h>
+    #include "pic24f/pic24f_hal.h"
+    #include "pic24f/uart.h"
+#elif HAL_TYPE == HAL_sam4l
+    #include "sam4l/sam4l_hal.h"
+#elif HAL_TYPE == HAL_stm32f0
+	#include "stm32f0/stm32f0_hal.h"
+#elif HAL_TYPE == HAL_stm32f1
+	#include "stm32f1/stm32f1_hal.h"
+#elif HAL_TYPE == HAL_stm32f2
+	#include "stm32f2/stm32f2_hal.h"
+#elif HAL_TYPE == HAL_stm32f3
+	#include "stm32f3/stm32f3_hal.h"
+	#ifdef SECCAN
+		#include "stm32f3/stm32f3_hal_seccan.h"
+	#endif
+#elif HAL_TYPE == HAL_stm32f4
+	#include "stm32f4/stm32f4_hal.h"
+#elif HAL_TYPE == HAL_cc2538
+	#include "cc2538/cc2538_hal.h"
+#elif HAL_TYPE == HAL_k24f
+    #include "k24f/k24f_hal.h"
+#elif HAL_TYPE == HAL_k82f
+#include "k82f/k82f_hal.h"
+#elif HAL_TYPE == HAL_nrf52840
+    #include "nrf52840/nrf52840_hal.h"   
+#elif HAL_TYPE == HAL_stm32f0_nano
+    #include "stm32f0/stm32f0_hal.h" 
+#elif HAL_TYPE == HAL_aurix
+    #include "aurix/aurix_hal.h"
+#elif HAL_TYPE == HAL_saml11
+     #include "saml11/saml11_hal.h"
+#elif HAL_TYPE == HAL_efm32tg11b
+     #include "efm32tg11b/efm32tg11b_hal.h"
+#elif HAL_TYPE == HAL_lpc55s6x
+     #include "lpc55s6x/lpc55s6x_hal.h"
+#elif HAL_TYPE == HAL_psoc62
+    #include "psoc62/psoc62_hal.h"
+#elif HAL_TYPE == HAL_imxrt1062
+    #include "imxrt1062/imxrt1062_hal.h"
+#elif HAL_TYPE == HAL_fe310
+    #include "fe310/fe310_hal.h"
+#elif HAL_TYPE == HAL_efr32mg21a
+    #include "efr32mg21a/efr32mg21a_hal.h"
+#elif HAL_TYPE == HAL_efm32gg11
+    #include "efm32gg11/efm32gg11_hal.h"
+#elif HAL_TYPE == HAL_stm32l5
+    #include "stm32l5/stm32l5_hal.h"
+#elif HAL_TYPE == HAL_stm32l4
+    #include "stm32l4/stm32l4_hal.h"
+#elif HAL_TYPE == HAL_rx65n
+    #include "rx65n/rx65n_hal.h"
+#elif HAL_TYPE == HAL_mpc5676r
+    #include "mpc5676r/MPC5676R_hal.h"
+#elif HAL_TYPE == HAL_neorv32
+    #include "neorv32/neorv32_hal.h"
+#elif HAL_TYPE == HAL_sam4s
+    #include "sam4s/sam4s_hal.h"
+#elif HAL_TYPE == HAL_ibex
+    #include "ibex/ibex_hal.h"
+#else
+    #error "Unsupported HAL Type"
+#endif
+
+#if PLATFORM == CW308_MEGARF
+    #undef trigger_setup
+    #undef trigger_high
+    #undef trigger_low
+    #define trigger_setup() DDRD |= 0x02
+    #define trigger_high()  PORTD |= 0x02
+    #define trigger_low()   PORTD &= ~(0x02)
+    
+    #define HW_AES128_Init();      AES_CTRL = 0x00;
+
+    #define HW_AES128_LoadKey(key);  for (uint8_t i = 0; i < 16; i++){ \
+                                     AES_KEY = *(key+i); \
+                                  }
+
+    #define HW_AES128_Enc(pt);  for (uint8_t i = 0; i < 16; i++){ \
+                                    AES_STATE = *(pt+i); \
+                                } \
+                                  \
+                                AES_CTRL |= 1<<AES_REQUEST; \
+                                  \
+                                /*Wait for done  */ \
+                                while ((AES_STATUS & (1<<AES_DONE)) == 0){ \
+                                    ; \
+                                } \
+                                  \
+                                for (uint8_t i = 0; i < 16; i++){ \
+                                    *(pt+i) = AES_STATE; \
+                                }
+    
+#endif
+
+
+#ifndef led_error
+#define led_error(a)
+#endif
+
+#ifndef led_ok
+#define led_ok(a)
+#endif
+
+#endif //HAL_H_

--- a/vendor/newae/hal/ibex/ibex_hal.c
+++ b/vendor/newae/hal/ibex/ibex_hal.c
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ibex_hal.h"
+#include "uart.h"
+#include "gpio.h"
+#include "demo_system.h"
+
+void trigger_high (void) {
+    set_outputs(GPIO_OUT, 0x01);
+}
+
+void trigger_low (void) {
+    set_outputs(GPIO_OUT, 0x00);
+}
+
+int getch (void) {
+    int uart_in_char;
+    while ((uart_in_char = uart_in(DEFAULT_UART)) == -1) {
+    }
+    return uart_in_char;
+}
+
+void putch (char c) {
+    uart_out(DEFAULT_UART, c);
+}
+
+void print (const char *ptr) {
+    while (*ptr != 0) {
+        uart_out(DEFAULT_UART, *ptr);
+        ptr++;
+    }
+}
+
+void platform_init(void) {
+}
+
+void init_uart(void) {
+    //uart_enable_rx_int(); note: not needed as this is for when using interrupts
+}
+
+void trigger_setup(void) {
+    set_outputs(GPIO_OUT, 0x00);
+}

--- a/vendor/newae/hal/ibex/ibex_hal.h
+++ b/vendor/newae/hal/ibex/ibex_hal.h
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef IBEX_HAL_H
+#define IBEX_HAL_H
+
+void trigger_high (void);
+
+void trigger_low (void);
+
+int getch (void);
+
+void putch (char c);
+
+void print (const char *ptr);
+
+void init_uart(void);
+
+void trigger_setup(void);
+
+void platform_init(void);
+
+#endif

--- a/vendor/newae/simpleserial-aes/simpleserial-aes.c
+++ b/vendor/newae/simpleserial-aes/simpleserial-aes.c
@@ -1,0 +1,178 @@
+/*
+    This file is part of the ChipWhisperer Example Targets
+    Copyright (C) 2012-2017 NewAE Technology Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "aes-independant.h"
+#include "simpleserial.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include "hal.h"
+
+uint8_t get_mask(uint8_t* m, uint8_t len)
+{
+  aes_indep_mask(m, len);
+  return 0x00;
+}
+
+uint8_t get_key(uint8_t* k, uint8_t len)
+{
+	aes_indep_key(k);
+	return 0x00;
+}
+
+uint8_t get_pt(uint8_t* pt, uint8_t len)
+{
+    aes_indep_enc_pretrigger(pt);
+
+	trigger_high();
+
+  #ifdef ADD_JITTER
+  for (volatile uint8_t k = 0; k < (*pt & 0x0F); k++);
+  #endif
+
+	aes_indep_enc(pt); /* encrypting the data block */
+	trigger_low();
+
+    aes_indep_enc_posttrigger(pt);
+
+	simpleserial_put('r', 16, pt);
+	return 0x00;
+}
+
+uint8_t reset(uint8_t* x, uint8_t len)
+{
+    // Reset key here if needed
+	return 0x00;
+}
+
+static uint16_t num_encryption_rounds = 10;
+
+uint8_t enc_multi_getpt(uint8_t* pt, uint8_t len)
+{
+    aes_indep_enc_pretrigger(pt);
+
+    for(unsigned int i = 0; i < num_encryption_rounds; i++){
+        trigger_high();
+        aes_indep_enc(pt);
+        trigger_low();
+    }
+
+    aes_indep_enc_posttrigger(pt);
+	simpleserial_put('r', 16, pt);
+    return 0;
+}
+
+uint8_t enc_multi_setnum(uint8_t* t, uint8_t len)
+{
+    //Assumes user entered a number like [0, 200] to mean "200"
+    //which is most sane looking for humans I think
+    num_encryption_rounds = t[1];
+    num_encryption_rounds |= t[0] << 8;
+    return 0;
+}
+
+uint8_t info(uint8_t* x, uint8_t len)
+{
+    print("Simpleserial-aes on Ibex, compiled ");
+    print(__DATE__);
+    print(", ");
+    print(__TIME__);
+    print("\n");
+    return 0x00;
+}
+
+#if SS_VER == SS_VER_2_1
+uint8_t aes(uint8_t cmd, uint8_t scmd, uint8_t len, uint8_t *buf)
+{
+    uint8_t req_len = 0;
+    uint8_t err = 0;
+    uint8_t mask_len = 0;
+    if (scmd & 0x04) {
+        // Mask has variable length. First byte encodes the length
+        mask_len = buf[req_len];
+        req_len += 1 + mask_len;
+        if (req_len > len) {
+            return SS_ERR_LEN;
+        }
+        err = get_mask(buf + req_len - mask_len, mask_len);
+        if (err)
+            return err;
+    }
+
+    if (scmd & 0x02) {
+        req_len += 16;
+        if (req_len > len) {
+            return SS_ERR_LEN;
+        }
+        err = get_key(buf + req_len - 16, 16);
+        if (err)
+            return err;
+    }
+    if (scmd & 0x01) {
+        req_len += 16;
+        if (req_len > len) {
+            return SS_ERR_LEN;
+        }
+        err = get_pt(buf + req_len - 16, 16);
+        if (err)
+            return err;
+    }
+
+    if (len != req_len) {
+        return SS_ERR_LEN;
+    }
+
+    return 0x00;
+
+}
+#endif
+
+int main(void)
+{
+	uint8_t tmp[KEY_LENGTH] = {DEFAULT_KEY};
+
+    platform_init();
+    init_uart();
+    trigger_setup();
+
+	aes_indep_init();
+	aes_indep_key(tmp);
+
+    /* Uncomment this to get a HELLO message for debug */
+
+    // putch('h');
+    // putch('e');
+    // putch('l');
+    // putch('l');
+    // putch('o');
+    // putch('\n');
+
+	simpleserial_init();
+    #if SS_VER == SS_VER_2_1
+    simpleserial_addcmd(0x01, 16, aes);
+    #else
+    simpleserial_addcmd('k', 16, get_key);
+    simpleserial_addcmd('p', 16,  get_pt);
+    simpleserial_addcmd('x',  0,   reset);
+    simpleserial_addcmd_flags('m', 18, get_mask, CMD_FLAG_LEN);
+    simpleserial_addcmd('s', 2, enc_multi_setnum);
+    simpleserial_addcmd('f', 16, enc_multi_getpt);
+    simpleserial_addcmd('i', 1, info);
+    #endif
+    while(1)
+        simpleserial_get();
+}

--- a/vendor/newae/simpleserial-ecc/simpleserial-ecc.c
+++ b/vendor/newae/simpleserial-ecc/simpleserial-ecc.c
@@ -1,0 +1,167 @@
+/*
+    This file is part of the ChipWhisperer Example Targets
+    Copyright (C) 2021 NewAE Technology Inc.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "uECC.c"
+#include "uECC_vli.h"
+#include "types.h"
+
+#include "hal.h"
+#include "simpleserial.h"
+#include <stdint.h>
+#include <stdlib.h>
+
+// Use globals for pmul input (P) and output (Q) points because
+// they're too big to transmit all in one simpleserial transfer:
+uECC_word_t P[uECC_MAX_WORDS * 2];
+uECC_word_t Q[uECC_MAX_WORDS * 2];
+
+uint8_t set_px(uint8_t* x, uint8_t len)
+{
+   int i, j;
+   for (i = 0; i < 8; i++) {
+      P[7-i] = 0;
+      for (j = 0; j < 4; j++) {
+         P[7-i] |= x[i*4+j] << ((3-j)*8);
+      }
+   }
+   return 0x00;
+}
+
+
+uint8_t set_py(uint8_t* y, uint8_t len)
+{
+   // TODO: this conversion is used in multiple places, move it to a function:
+   int i, j;
+   for (i = 0; i < 8; i++) {
+      P[15-i] = 0;
+      for (j = 0; j < 4; j++) {
+         P[15-i] |= y[i*4+j] << ((3-j)*8);
+      }
+   }
+   return 0x00;
+}
+
+
+uint8_t get_qx(uint8_t* x, uint8_t len)
+{
+    int i, j;
+    for (i = 0; i < 8; i++) {
+       for (j = 0; j < 4; j++) {
+          x[i*4+j] = (int)((Q[7-i] >> (3-j)*8) & 255);
+       }
+    }
+    simpleserial_put('r', 32, x);
+    return 0x00;
+}
+
+
+uint8_t get_qy(uint8_t* y, uint8_t len)
+{
+    int i, j;
+    for (i = 0; i < 8; i++) {
+       for (j = 0; j < 4; j++) {
+          y[i*4+j] = (int)((Q[15-i] >> (3-j)*8) & 255);
+       }
+    }
+    simpleserial_put('r', 32, y);
+    return 0x00;
+}
+
+
+
+uint8_t run_pmul(uint8_t* k, uint8_t len)
+{
+    const struct uECC_Curve_t * curve;
+    uECC_word_t kwords[uECC_MAX_WORDS];
+    curve = uECC_secp256r1();
+
+    int i, j;
+    for (i = 0; i < 8; i++) {
+       kwords[7-i] = 0;
+       for (j = 0; j < 4; j++) {
+          kwords[7-i] |= k[i*4+j] << ((3-j)*8);
+       }
+    }
+
+    trigger_high();
+    uECC_point_mult(Q, P, kwords, curve);
+    trigger_low();
+    return 0x00;
+}
+
+
+uint8_t run_pmul_fixed(uint8_t* k, uint8_t len)
+{
+    const struct uECC_Curve_t * curve;
+    uECC_word_t kwords[uECC_MAX_WORDS];
+    curve = uECC_secp256r1();
+
+    int i, j;
+    for (i = 0; i < 8; i++) {
+       kwords[7-i] = 0;
+       for (j = 0; j < 4; j++) {
+          kwords[7-i] |= k[i*4+j] << ((3-j)*8);
+       }
+    }
+
+    trigger_high();
+    uECC_point_mult(Q, curve->G, kwords, curve);
+    trigger_low();
+    return 0x00;
+}
+
+
+
+
+uint8_t reset(uint8_t* x, uint8_t len)
+{
+    // Reset key here if needed
+	return 0x00;
+}
+
+
+uint8_t info(uint8_t* x, uint8_t len)
+{
+        print("ChipWhisperer simpleserial-ecc on Ibex, compiled ");
+        print(__DATE__);
+        print(", ");
+        print(__TIME__);
+        print("\n");
+	return 0x00;
+}
+
+
+int main(void)
+{
+    platform_init();
+    init_uart();
+    trigger_setup();
+
+    simpleserial_init();
+    simpleserial_addcmd('k', 32, run_pmul);
+    simpleserial_addcmd('f', 32, run_pmul_fixed);
+    simpleserial_addcmd('a', 32, set_px);
+    simpleserial_addcmd('b', 32, set_py);
+    simpleserial_addcmd('p', 32, get_qx);
+    simpleserial_addcmd('q', 32, get_qy);
+    simpleserial_addcmd('x',  0, reset);
+    simpleserial_addcmd('i',  1, info);
+
+    while(1)
+        simpleserial_get();
+}

--- a/vendor/newae/simpleserial/simpleserial.c
+++ b/vendor/newae/simpleserial/simpleserial.c
@@ -1,0 +1,441 @@
+// simpleserial.c
+
+#include "simpleserial.h"
+#include <stdint.h>
+//#include "cw.h"
+#include "hal.h"
+
+
+#define MAX_SS_CMDS 16
+static int num_commands = 0;
+
+#define MAX_SS_LEN 256
+
+//#define SS_VER_1_0 0
+//#define SS_VER_1_1 1
+//#define SS_VER_2_0 2
+
+
+// 0xA6 formerly 
+#define CW_CRC 0x4D 
+uint8_t ss_crc(uint8_t *buf, uint8_t len)
+{
+	unsigned int k = 0;
+	uint8_t crc = 0x00;
+	while (len--) {
+		crc ^= *buf++;
+		for (k = 0; k < 8; k++) {
+			crc = crc & 0x80 ? (crc << 1) ^ CW_CRC: crc << 1;
+		}
+	}
+	return crc;
+
+}
+
+// [B_STUFF, CMD, SCMD, LEN, B_STUFF, DATA..., CRC, TERM]
+
+//#define SS_VER SS_VER_2_0
+#if SS_VER == SS_VER_2_0
+#error "SS_VER_2_0 is deprecated! Use SS_VER_2_1 instead."
+#elif SS_VER == SS_VER_2_1
+
+int hex_decode(int len, char* ascii_buf, uint8_t* data_buf)
+{
+	for(int i = 0; i < len; i++)
+	{
+		char n_hi = ascii_buf[2*i];
+		char n_lo = ascii_buf[2*i+1];
+
+		if(n_lo >= '0' && n_lo <= '9')
+			data_buf[i] = n_lo - '0';
+		else if(n_lo >= 'A' && n_lo <= 'F')
+			data_buf[i] = n_lo - 'A' + 10;
+		else if(n_lo >= 'a' && n_lo <= 'f')
+			data_buf[i] = n_lo - 'a' + 10;
+		else
+			return 1;
+
+		if(n_hi >= '0' && n_hi <= '9')
+			data_buf[i] |= (n_hi - '0') << 4;
+		else if(n_hi >= 'A' && n_hi <= 'F')
+			data_buf[i] |= (n_hi - 'A' + 10) << 4;
+		else if(n_hi >= 'a' && n_hi <= 'f')
+			data_buf[i] |= (n_hi - 'a' + 10) << 4;
+		else
+			return 1;
+	}
+
+	return 0;
+}
+
+typedef struct ss_cmd
+{
+	char c;
+	unsigned int len;
+	uint8_t (*fp)(uint8_t, uint8_t, uint8_t, uint8_t *);
+} ss_cmd;
+static ss_cmd commands[MAX_SS_CMDS];
+
+void ss_puts(char *x)
+{
+	do {
+		putch(*x);
+	} while (*++x);
+}
+
+#define FRAME_BYTE 0x00
+
+uint8_t check_version(uint8_t cmd, uint8_t scmd, uint8_t len, uint8_t *data)
+{
+	uint8_t ver = SS_VER;
+	simpleserial_put('r', 1, &ver);
+	return SS_ERR_OK;
+}
+
+uint8_t ss_get_commands(uint8_t cmd, uint8_t scmd, uint8_t len, uint8_t *data)
+{
+    uint8_t cmd_chars[MAX_SS_CMDS];
+    for (uint8_t i = 0; i < (num_commands & 0xFF); i++) {
+        cmd_chars[i] = commands[i].c;
+    }
+
+    simpleserial_put('r', num_commands & 0xFF, (void *)cmd_chars);
+    return 0x00;
+
+}
+
+uint8_t stuff_data(uint8_t *buf, uint8_t len)
+{
+	uint8_t i = 1;
+	uint8_t last = 0;
+	for (; i < len; i++) {
+		if (buf[i] == FRAME_BYTE) {
+			buf[last] = i - last;
+			last = i;
+		}
+	}
+	return 0x00;
+}
+
+uint8_t unstuff_data(uint8_t *buf, uint8_t len)
+{
+	uint8_t next = buf[0];
+	buf[0] = 0x00;
+	//len -= 1;
+	uint8_t tmp = next;
+	while ((next < len) && tmp != 0) {
+		tmp = buf[next];
+		buf[next] = FRAME_BYTE;
+		next += tmp;
+	}
+	return next;
+}
+
+// Set up the SimpleSerial module by preparing internal commands
+// This just adds the "v" command for now...
+void simpleserial_init()
+{
+	simpleserial_addcmd('v', 0, check_version);
+    simpleserial_addcmd('w', 0, ss_get_commands);
+}
+
+int simpleserial_addcmd(char c, unsigned int len, uint8_t (*fp)(uint8_t, uint8_t, uint8_t, uint8_t*))
+{
+	if(num_commands >= MAX_SS_CMDS) {
+		putch('a');
+		return 1;
+	}
+
+	if(len >= MAX_SS_LEN) {
+		putch('b');
+		return 1;
+	}
+
+	commands[num_commands].c   = c;
+	commands[num_commands].len = len;
+	commands[num_commands].fp  = fp;
+	num_commands++;
+
+	return 0;
+}
+
+void simpleserial_get(void)
+{
+	uint8_t data_buf[MAX_SS_LEN];
+	uint8_t err = 0;
+
+	for (int i = 0; i < 4; i++) {
+		data_buf[i] = getch(); //PTR, cmd, scmd, len
+		if (data_buf[i] == FRAME_BYTE) {
+			err = SS_ERR_FRAME_BYTE;
+			goto ERROR;
+		}
+	}
+	uint8_t next_frame = unstuff_data(data_buf, 4);
+
+	// check for valid command
+	uint8_t c = 0;
+	for(c = 0; c < num_commands; c++)
+	{
+		if(commands[c].c == data_buf[1])
+			break;
+	}
+
+	if (c == num_commands) {
+		err = SS_ERR_CMD;
+		goto ERROR;
+	}
+
+	//check that next frame not beyond end of message
+	// account for cmd, scmd, len, data, crc, end of frame
+	if ((data_buf[3] + 5) < next_frame) {
+		err = SS_ERR_LEN;
+		goto ERROR;
+	}
+
+	// read in data
+	// eq to len + crc + frame end
+	int i = 4;
+	for (; i < data_buf[3] + 5; i++) {
+		data_buf[i] = getch();
+		if (data_buf[i] == FRAME_BYTE) {
+			err = SS_ERR_FRAME_BYTE;
+			goto ERROR;
+		}
+	}
+
+	//check that final byte is the FRAME_BYTE
+	data_buf[i] = getch();
+	if (data_buf[i] != FRAME_BYTE) {
+		err = SS_ERR_LEN;
+		goto ERROR;
+	}
+
+	//fully unstuff data now
+	unstuff_data(data_buf + next_frame, i - next_frame + 1);
+
+	//calc crc excluding original frame offset and frame end and crc
+	uint8_t crc = ss_crc(data_buf+1, i-2);
+	if (crc != data_buf[i-1]) {
+		err = SS_ERR_CRC;
+		goto ERROR;
+	}
+
+	err = commands[c].fp(data_buf[1], data_buf[2], data_buf[3], data_buf+4);
+
+ERROR:
+	simpleserial_put('e', 0x01, &err);
+	return;
+}
+
+void simpleserial_put(char c, uint8_t size, uint8_t* output)
+{
+	uint8_t data_buf[MAX_SS_LEN];
+	data_buf[0] = 0x00;
+	data_buf[1] = c;
+	data_buf[2] = size;
+	int i = 0;
+	for (; i < size; i++) {
+		data_buf[i + 3] = output[i];
+	}
+	data_buf[i + 3] = ss_crc(data_buf+1, size+2);
+	data_buf[i + 4] = 0x00;
+	stuff_data(data_buf, i + 5);
+	for (int i = 0; i < size + 5; i++) {
+		putch(data_buf[i]);
+	}
+}
+
+
+#else
+
+typedef struct ss_cmd
+{
+	char c;
+	unsigned int len;
+	uint8_t (*fp)(uint8_t*, uint8_t);
+	uint8_t flags;
+} ss_cmd;
+static ss_cmd commands[MAX_SS_CMDS];
+// Callback function for "v" command.
+// This can exist in v1.0 as long as we don't actually send back an ack ("z")
+uint8_t check_version(uint8_t *v, uint8_t len)
+{
+	return SS_VER;
+}
+
+uint8_t ss_num_commands(uint8_t *x, uint8_t len)
+{
+    uint8_t ncmds = num_commands & 0xFF;
+    simpleserial_put('r', 0x01, &ncmds);
+    return 0x00;
+}
+
+typedef struct ss_cmd_repr {
+    uint8_t c;
+    uint8_t len;
+    uint8_t flags;
+} ss_cmd_repr;
+
+uint8_t ss_get_commands(uint8_t *x, uint8_t len)
+{
+    ss_cmd_repr repr_cmd_buf[MAX_SS_CMDS];
+    for (uint8_t i = 0; i < (num_commands & 0xFF); i++) {
+        repr_cmd_buf[i].c = commands[i].c;
+        repr_cmd_buf[i].len = commands[i].len;
+        repr_cmd_buf[i].flags = commands[i].flags;
+    }
+
+    simpleserial_put('r', num_commands * 0x03, (void *) repr_cmd_buf);
+    return 0x00;
+}
+
+static char hex_lookup[16] =
+{
+	'0', '1', '2', '3', '4', '5', '6', '7',
+	'8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
+};
+
+int hex_decode(int len, char* ascii_buf, uint8_t* data_buf)
+{
+	for(int i = 0; i < len; i++)
+	{
+		char n_hi = ascii_buf[2*i];
+		char n_lo = ascii_buf[2*i+1];
+
+		if(n_lo >= '0' && n_lo <= '9')
+			data_buf[i] = n_lo - '0';
+		else if(n_lo >= 'A' && n_lo <= 'F')
+			data_buf[i] = n_lo - 'A' + 10;
+		else if(n_lo >= 'a' && n_lo <= 'f')
+			data_buf[i] = n_lo - 'a' + 10;
+		else
+			return 1;
+
+		if(n_hi >= '0' && n_hi <= '9')
+			data_buf[i] |= (n_hi - '0') << 4;
+		else if(n_hi >= 'A' && n_hi <= 'F')
+			data_buf[i] |= (n_hi - 'A' + 10) << 4;
+		else if(n_hi >= 'a' && n_hi <= 'f')
+			data_buf[i] |= (n_hi - 'a' + 10) << 4;
+		else
+			return 1;
+	}
+
+	return 0;
+}
+
+
+
+// Set up the SimpleSerial module by preparing internal commands
+// This just adds the "v" command for now...
+void simpleserial_init()
+{
+	simpleserial_addcmd('v', 0, check_version);
+    simpleserial_addcmd('w', 0, ss_get_commands);
+    simpleserial_addcmd('y', 0, ss_num_commands);
+}
+
+int simpleserial_addcmd(char c, unsigned int len, uint8_t (*fp)(uint8_t*, uint8_t))
+{
+	return simpleserial_addcmd_flags(c, len, fp, CMD_FLAG_NONE);
+}
+
+int simpleserial_addcmd_flags(char c, unsigned int len, uint8_t (*fp)(uint8_t*, uint8_t), uint8_t fl)
+{
+	if(num_commands >= MAX_SS_CMDS)
+		return 1;
+
+	if(len >= MAX_SS_LEN)
+		return 1;
+
+	commands[num_commands].c   = c;
+	commands[num_commands].len = len;
+	commands[num_commands].fp  = fp;
+	commands[num_commands].flags = fl;
+	num_commands++;
+
+	return 0;
+}
+
+void simpleserial_get(void)
+{
+	char ascii_buf[2*MAX_SS_LEN];
+	uint8_t data_buf[MAX_SS_LEN];
+	char c;
+
+	// Find which command we're receiving
+	c = getch();
+
+	int cmd;
+	for(cmd = 0; cmd < num_commands; cmd++)
+	{
+		if(commands[cmd].c == c)
+			break;
+	}
+
+	// If we didn't find a match, give up right away
+	if(cmd == num_commands)
+		return;
+
+	// If flag CMD_FLAG_LEN is set, the next byte indicates the sent length
+	if ((commands[cmd].flags & CMD_FLAG_LEN) != 0)
+	{
+		uint8_t l = 0;
+		char buff[2];
+		buff[0] = getch();
+		buff[1] = getch();
+		if (hex_decode(1, buff, &l))
+			return;
+		commands[cmd].len = l;
+	}
+
+	// Receive characters until we fill the ASCII buffer
+	for(int i = 0; i < 2*commands[cmd].len; i++)
+	{
+		c = getch();
+
+		// Check for early \n
+		if(c == '\n' || c == '\r')
+			return;
+
+		ascii_buf[i] = c;
+	}
+
+	// Assert that last character is \n or \r
+	c = getch();
+	if(c != '\n' && c != '\r')
+		return;
+
+	// ASCII buffer is full: convert to bytes
+	// Check for illegal characters here
+	if(hex_decode(commands[cmd].len, ascii_buf, data_buf))
+		return;
+
+	// Callback
+	uint8_t ret[1];
+	ret[0] = commands[cmd].fp(data_buf, commands[cmd].len);
+
+	// Acknowledge (if version is 1.1)
+#if SS_VER == SS_VER_1_1
+	simpleserial_put('z', 1, ret);
+#endif
+}
+
+void simpleserial_put(char c, uint8_t size, uint8_t* output)
+{
+	// Write first character
+	putch(c);
+
+	// Write each byte as two nibbles
+	for(int i = 0; i < size; i++)
+	{
+		putch(hex_lookup[output[i] >> 4 ]);
+		putch(hex_lookup[output[i] & 0xF]);
+	}
+
+	// Write trailing '\n'
+	putch('\n');
+}
+
+#endif

--- a/vendor/newae/simpleserial/simpleserial.h
+++ b/vendor/newae/simpleserial/simpleserial.h
@@ -1,0 +1,74 @@
+// simpleserial.h
+// Generic module for interpreting SimpleSerial commands
+
+#ifndef SIMPLESERIAL_H
+#define SIMPLESERIAL_H
+
+#include <stdint.h>
+
+#define SS_VER_1_0 0
+#define SS_VER_1_1 1
+#define SS_VER_2_0 2
+#define SS_VER_2_1 3
+
+#ifndef SS_VER
+	#define SS_VER SS_VER_1_1
+	#warning "SS_VER undefined! Setting SS_VER=SS_VER_1_1"
+#endif
+
+// Set up the SimpleSerial module
+// This prepares any internal commands
+void simpleserial_init(void);
+
+// Add a command to the SimpleSerial module
+// Args:
+// - c:   The character designating this command
+// - len: The number of bytes expected
+// - fp:  A pointer to a callback, which is called after receiving data
+// - fl:  Bitwise OR'd CMD_FLAG_* values. Defaults to CMD_FLAG_NONE when
+//        calling simpleserial_addcmd()
+// Example: simpleserial_addcmd('p', 16, encrypt_text)
+// - Calls encrypt_text() with a 16 byte array after receiving a line
+//   like p00112233445566778899AABBCCDDEEFF\n
+// Notes:
+// - Maximum of 10 active commands
+// - Maximum length of 64 bytes
+// - Returns 1 if either of these fail; otherwise 0
+// - The callback function returns a number in [0x00, 0xFF] as a status code;
+//   in protocol v1.1, this status code is returned through a "z" message
+#if SS_VER == SS_VER_2_1
+int simpleserial_addcmd(char c, unsigned int len, uint8_t (*fp)(uint8_t, uint8_t, uint8_t, uint8_t*));
+#else
+
+#define CMD_FLAG_NONE	0x00
+// If this flag is set, the command supports variable length payload.
+// The first byte (hex-encoded) indicates the length.
+#define CMD_FLAG_LEN	0x01
+
+int simpleserial_addcmd_flags(char c, unsigned int len, uint8_t (*fp)(uint8_t*, uint8_t), uint8_t);
+int simpleserial_addcmd(char c, unsigned int len, uint8_t (*fp)(uint8_t*, uint8_t));
+#endif
+
+// Attempt to process a command
+// If a full string is found, the relevant callback function is called
+// Might return without calling a callback for several reasons:
+// - First character didn't match any known commands
+// - One of the characters wasn't in [0-9|A-F|a-f]
+// - Data was too short or too long
+void simpleserial_get(void);
+
+// Write some data to the serial port
+// Prepends the character c to the start of the line
+// Example: simpleserial_put('r', 16, ciphertext)
+void simpleserial_put(char c, uint8_t size, uint8_t* output);
+
+typedef enum ss_err_cmd {
+	SS_ERR_OK,
+	SS_ERR_CMD,
+	SS_ERR_CRC,
+	SS_ERR_TIMEOUT,
+    SS_ERR_LEN,
+    SS_ERR_FRAME_BYTE
+} ss_err_cmd;
+
+#endif // SIMPLESERIAL_H


### PR DESCRIPTION
This adds support for the CW305 and CW312-A35 FPGA target boards. It also includes, as examples, two applications that are used in our existing set of Jupyter notebook courses (note that applications can also be built over in ChipWhisperer land with the recent addition of the Ibex HAL there: https://github.com/newaetech/chipwhisperer/commit/1aab0059731997b862e9cf50c5d390f33ee26fed).