### PR TITLE
[sw] Apply common CMake conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ to a verilator simulation model to be simulated on a PC.
 ```
 mkdir sw/build
 pushd sw/build
-cmake ../
+cmake ..
 make
 popd
 ```

--- a/sw/CMakeLists.txt
+++ b/sw/CMakeLists.txt
@@ -1,5 +1,15 @@
-cmake_minimum_required(VERSION 3.10)
-project(demo_system_sw)
+cmake_minimum_required(VERSION 3.12)
+
+if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+  set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/gcc_toolchain.cmake")
+endif()
+
+project(demo_system_sw LANGUAGES C ASM)
+
+if(CMAKE_BUILD_TYPE STREQUAL "")
+  get_property(helpstring CACHE CMAKE_BUILD_TYPE PROPERTY HELPSTRING)
+  set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "${helpstring}" FORCE)
+endif()
 
 option(SIM_CTRL_OUTPUT
        "Send string output to simulator control rather than UART")
@@ -8,19 +18,6 @@ if(SIM_CTRL_OUTPUT)
   add_compile_definitions(SIM_CTRL_OUTPUT)
 endif()
 
-set(COMMON_DIR "${CMAKE_CURRENT_LIST_DIR}/common")
-set(LINKER_SCRIPT "${COMMON_DIR}/link.ld")
-set(CMAKE_C_COMPILER riscv32-unknown-elf-gcc)
-set(CMAKE_EXE_LINKER_FLAGS "-nostartfiles -T${LINKER_SCRIPT}")
-set(CMAKE_C_FLAGS "-march=rv32imc -mabi=ilp32 -static -mcmodel=medany -Wall -g \
-  -fvisibility=hidden -ffreestanding")
-
 add_subdirectory(common)
-
-function(add_prog prog_name srcs)
-  add_executable(${prog_name} ${srcs} $<TARGET_OBJECTS:common>)
-  target_include_directories(${prog_name} PRIVATE $<TARGET_PROPERTY:common,INCLUDE_DIRECTORIES>)
-endfunction()
-
 add_subdirectory(demo)
 add_subdirectory(blank)

--- a/sw/blank/CMakeLists.txt
+++ b/sw/blank/CMakeLists.txt
@@ -1,8 +1,7 @@
 add_executable(blank blank.S)
-set_property(SOURCE blank.S PROPERTY LANGUAGE C)
 
 add_custom_command(
   TARGET blank POST_BUILD
-  COMMAND riscv32-unknown-elf-objcopy -O binary "$<TARGET_FILE:blank>" "$<TARGET_FILE:blank>.bin"
+  COMMAND ${CMAKE_OBJCOPY} -O binary "$<TARGET_FILE:blank>" "$<TARGET_FILE:blank>.bin"
   COMMAND srec_cat "$<TARGET_FILE:blank>.bin" -binary -offset 0x0000 -byte-swap 4 -o "$<TARGET_FILE:blank>.vmem" -vmem
   VERBATIM)

--- a/sw/common/CMakeLists.txt
+++ b/sw/common/CMakeLists.txt
@@ -1,3 +1,2 @@
 add_library(common OBJECT demo_system.c uart.c timer.c gpio.c pwm.c spi.c crt0.S)
-set_property(SOURCE crt0.S PROPERTY LANGUAGE C)
-target_include_directories(common PUBLIC "${CMAKE_CURRENT_LIST_DIR}")
+target_include_directories(common INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/sw/demo/basic-passwdcheck/CMakeLists.txt
+++ b/sw/demo/basic-passwdcheck/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/newae/simpleseri
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../common)
 
 
-add_prog(basic-passwdcheck ${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/newae/basic-passwdcheck/basic-passwdcheck.c)
+add_executable(basic-passwdcheck ${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/newae/basic-passwdcheck/basic-passwdcheck.c)
 
-target_link_libraries(basic-passwdcheck simpleserial)
+target_link_libraries(basic-passwdcheck common simpleserial)
 

--- a/sw/demo/hello_world/CMakeLists.txt
+++ b/sw/demo/hello_world/CMakeLists.txt
@@ -1,1 +1,2 @@
-add_prog(demo main.c)
+add_executable(demo main.c)
+target_link_libraries(demo common)

--- a/sw/demo/lcd_st7735/CMakeLists.txt
+++ b/sw/demo/lcd_st7735/CMakeLists.txt
@@ -6,12 +6,10 @@ ${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/display_drivers/core/lucida_console_
 ${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/display_drivers/st7735/lcd_st7735.c
 )
 
-string(APPEND CMAKE_C_FLAGS " -O2")
-
 # add_executable(lcd_st7735 main.c)
-add_prog(lcd_st7735 "main.c;lcd.c;fractal_fixed.c;fractal_float.c;fractal_palette.c")
+add_executable(lcd_st7735 main.c lcd.c fractal_fixed.c fractal_float.c fractal_palette.c)
 
 # pull in core dependencies and additional i2c hardware support
-target_link_libraries(lcd_st7735 lcd_st7735_lib)
+target_link_libraries(lcd_st7735 common lcd_st7735_lib)
 
 target_include_directories(lcd_st7735 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/display_drivers)

--- a/sw/demo/simpleserial-aes/CMakeLists.txt
+++ b/sw/demo/simpleserial-aes/CMakeLists.txt
@@ -16,7 +16,7 @@ ${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/newae/crypto/aes-independant.c
 ${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/newae/crypto/tiny-AES128-C/aes.c
 )
 
-add_prog(simpleserial-aes ${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/newae/simpleserial-aes/simpleserial-aes.c)
+add_executable(simpleserial-aes ${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/newae/simpleserial-aes/simpleserial-aes.c)
 
-target_link_libraries(simpleserial-aes simpleserial tiny-AES128)
+target_link_libraries(simpleserial-aes common simpleserial tiny-AES128)
 

--- a/sw/gcc_toolchain.cmake
+++ b/sw/gcc_toolchain.cmake
@@ -1,0 +1,7 @@
+set(LINKER_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/common/link.ld")
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_C_COMPILER riscv32-unknown-elf-gcc)
+set(CMAKE_C_FLAGS_INIT
+    "-march=rv32imc -mabi=ilp32 -mcmodel=medany -Wall -fvisibility=hidden -ffreestanding")
+set(CMAKE_ASM_FLAGS_INIT "-march=rv32imc")
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-nostartfiles -T \"${LINKER_SCRIPT}\"")


### PR DESCRIPTION
- Set the target compiler and flags in a toolchain file
  - Enhance portability to other toolchains
  - Enable compiler flags to be set in the CMake cache
  - Use the target toolchain instead of the host toolchain for CMake compiler detection
- Enable assembly language support
- Simplify linking the common library