### PR TITLE
[sw] Add a CMake option to choose whether to halt the core upon program termination

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,8 @@ make
 popd
 ```
 
+The HALT_SIM_WHEN_EXIT CMake option can be used to automatically stop the simulation when the program exits (`cmake -DHALT_SIM_WHEN_EXIT=ON ../`). This option should be disabled when building software for loading into an FPGA, otherwise the chip will not accept subsequent applications via the `util/load_demo_system.sh` script once the current program exits.
+
 Note the FPGA build relies on a fixed path to the initial binary (blank.vmem) so
 if you want to create your build directory elsewhere you need to adjust the path
 in `ibex_demo_system.core`

--- a/sw/CMakeLists.txt
+++ b/sw/CMakeLists.txt
@@ -3,9 +3,14 @@ project(demo_system_sw)
 
 option(SIM_CTRL_OUTPUT
        "Send string output to simulator control rather than UART")
+option(HALT_SIM_WHEN_EXIT
+       "Halt the simulator when the program exits otherwise the core will be kept in a sleep loop")
 
 if(SIM_CTRL_OUTPUT)
   add_compile_definitions(SIM_CTRL_OUTPUT)
+endif()
+if(HALT_SIM_WHEN_EXIT)
+  add_compile_definitions(HALT_SIM_WHEN_EXIT)
 endif()
 
 set(COMMON_DIR "${CMAKE_CURRENT_LIST_DIR}/common")

--- a/sw/common/crt0.S
+++ b/sw/common/crt0.S
@@ -67,10 +67,12 @@ main_entry:
   addi x11, x0, 0
   jal x1, main
 
+#ifdef HALT_SIM_WHEN_EXIT
   /* Halt simulation */
   li x5, SIM_CTRL_BASE + SIM_CTRL_CTRL
   li x6, 1
   sw x6, 0(x5)
+#endif
 
   /* If execution ends up here just put the core to sleep */
 sleep_loop:


### PR DESCRIPTION
Resolve #48 by adding a CMake option to choose whether to halt the core upon program termination