### PR TITLE
Add hjson to python requirements

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -4,6 +4,7 @@
 
 # Individual Python packages
 anytree
+hjson
 mako
 pyyaml
 wheel


### PR DESCRIPTION
The hjson requirement is needed to run `util/vendor.py` in the virtual environment.