### PR TITLE
Consistently use host and device for memory bus

### DIFF
--- a/rtl/system/dm_top.sv
+++ b/rtl/system/dm_top.sv
@@ -28,22 +28,22 @@ module dm_top #(
                                             // (e.g.: power down)
 
   // bus device with debug memory, for an execution based technique
-  input  logic                  slave_req_i,
-  input  logic                  slave_we_i,
-  input  logic [BusWidth-1:0]   slave_addr_i,
-  input  logic [BusWidth/8-1:0] slave_be_i,
-  input  logic [BusWidth-1:0]   slave_wdata_i,
-  output logic [BusWidth-1:0]   slave_rdata_o,
+  input  logic                  device_req_i,
+  input  logic                  device_we_i,
+  input  logic [BusWidth-1:0]   device_addr_i,
+  input  logic [BusWidth/8-1:0] device_be_i,
+  input  logic [BusWidth-1:0]   device_wdata_i,
+  output logic [BusWidth-1:0]   device_rdata_o,
 
   // bus host, for system bus accesses
-  output logic                  master_req_o,
-  output logic [BusWidth-1:0]   master_add_o,
-  output logic                  master_we_o,
-  output logic [BusWidth-1:0]   master_wdata_o,
-  output logic [BusWidth/8-1:0] master_be_o,
-  input  logic                  master_gnt_i,
-  input  logic                  master_r_valid_i,
-  input  logic [BusWidth-1:0]   master_r_rdata_i
+  output logic                  host_req_o,
+  output logic [BusWidth-1:0]   host_add_o,
+  output logic                  host_we_o,
+  output logic [BusWidth-1:0]   host_wdata_o,
+  output logic [BusWidth/8-1:0] host_be_o,
+  input  logic                  host_gnt_i,
+  input  logic                  host_r_valid_i,
+  input  logic [BusWidth-1:0]   host_r_rdata_i
 );
 
   `ASSERT_INIT(paramCheckNrHarts, NrHarts > 0)
@@ -164,14 +164,14 @@ module dm_top #(
   ) i_dm_sba (
     .clk_i                   ( clk_i                 ),
     .rst_ni                  ( rst_ni                ),
-    .master_req_o            ( master_req_o          ),
-    .master_add_o            ( master_add_o          ),
-    .master_we_o             ( master_we_o           ),
-    .master_wdata_o          ( master_wdata_o        ),
-    .master_be_o             ( master_be_o           ),
-    .master_gnt_i            ( master_gnt_i          ),
-    .master_r_valid_i        ( master_r_valid_i      ),
-    .master_r_rdata_i        ( master_r_rdata_i      ),
+    .master_req_o            ( host_req_o            ),
+    .master_add_o            ( host_add_o            ),
+    .master_we_o             ( host_we_o             ),
+    .master_wdata_o          ( host_wdata_o          ),
+    .master_be_o             ( host_be_o             ),
+    .master_gnt_i            ( host_gnt_i            ),
+    .master_r_valid_i        ( host_r_valid_i        ),
+    .master_r_rdata_i        ( host_r_rdata_i        ),
     .dmactive_i              ( dmactive_o            ),
     .sbaddress_i             ( sbaddress_csrs_sba    ),
     .sbaddress_o             ( sbaddress_sba_csrs    ),
@@ -220,12 +220,12 @@ module dm_top #(
     .data_i                  ( data_csrs_mem         ),
     .data_o                  ( data_mem_csrs         ),
     .data_valid_o            ( data_valid            ),
-    .req_i                   ( slave_req_i           ),
-    .we_i                    ( slave_we_i            ),
-    .addr_i                  ( slave_addr_i          ),
-    .wdata_i                 ( slave_wdata_i         ),
-    .be_i                    ( slave_be_i            ),
-    .rdata_o                 ( slave_rdata_o         )
+    .req_i                   ( device_req_i          ),
+    .we_i                    ( device_we_i           ),
+    .addr_i                  ( device_addr_i         ),
+    .wdata_i                 ( device_wdata_i        ),
+    .be_i                    ( device_be_i           ),
+    .rdata_o                 ( device_rdata_o        )
   );
 
   // Bound-in DPI module replaces the TAP

--- a/rtl/system/ibex_demo_system.sv
+++ b/rtl/system/ibex_demo_system.sv
@@ -101,7 +101,7 @@ module ibex_demo_system #(
   logic [31:0]    host_rdata    [NrHosts];
   logic           host_err      [NrHosts];
 
-  // devices (slaves)
+  // devices
   logic           device_req    [NrDevices];
   logic [31:0]    device_addr   [NrDevices];
   logic           device_we     [NrDevices];
@@ -123,13 +123,13 @@ module ibex_demo_system #(
   logic [31:0] mem_instr_rdata;
   logic        dbg_instr_req;
 
-  logic        dbg_slave_req;
-  logic [31:0] dbg_slave_addr;
-  logic        dbg_slave_we;
-  logic [ 3:0] dbg_slave_be;
-  logic [31:0] dbg_slave_wdata;
-  logic        dbg_slave_rvalid;
-  logic [31:0] dbg_slave_rdata;
+  logic        dbg_device_req;
+  logic [31:0] dbg_device_addr;
+  logic        dbg_device_we;
+  logic [ 3:0] dbg_device_be;
+  logic [31:0] dbg_device_wdata;
+  logic        dbg_device_rvalid;
+  logic [31:0] dbg_device_rdata;
 
   // Internally generated resets cause IMPERFECTSCH warnings
   /* verilator lint_off IMPERFECTSCH */
@@ -220,7 +220,7 @@ module ibex_demo_system #(
     end
   end
 
-  assign core_instr_rdata = core_instr_sel_dbg ? dbg_slave_rdata : mem_instr_rdata;
+  assign core_instr_rdata = core_instr_sel_dbg ? dbg_device_rdata : mem_instr_rdata;
 
   assign rst_core_n = rst_sys_ni & ~ndmreset_req;
 
@@ -426,19 +426,19 @@ module ibex_demo_system #(
     .timer_intr_o  (timer_irq)
   );
 
-  assign dbg_slave_req         = device_req[DbgDev] | dbg_instr_req;
-  assign dbg_slave_we          = device_req[DbgDev] & device_we[DbgDev];
-  assign dbg_slave_addr        = device_req[DbgDev] ? device_addr[DbgDev] : core_instr_addr;
-  assign dbg_slave_be          = device_be[DbgDev];
-  assign dbg_slave_wdata       = device_wdata[DbgDev];
-  assign device_rvalid[DbgDev] = dbg_slave_rvalid;
-  assign device_rdata[DbgDev]  = dbg_slave_rdata;
+  assign dbg_device_req        = device_req[DbgDev] | dbg_instr_req;
+  assign dbg_device_we         = device_req[DbgDev] & device_we[DbgDev];
+  assign dbg_device_addr       = device_req[DbgDev] ? device_addr[DbgDev] : core_instr_addr;
+  assign dbg_device_be         = device_be[DbgDev];
+  assign dbg_device_wdata      = device_wdata[DbgDev];
+  assign device_rvalid[DbgDev] = dbg_device_rvalid;
+  assign device_rdata[DbgDev]  = dbg_device_rdata;
 
   always @(posedge clk_sys_i or negedge rst_sys_ni) begin
     if (!rst_sys_ni) begin
-      dbg_slave_rvalid <= 1'b0;
+      dbg_device_rvalid <= 1'b0;
     end else begin
-      dbg_slave_rvalid <= device_req[DbgDev];
+      dbg_device_rvalid <= device_req[DbgDev];
     end
   end
 
@@ -455,22 +455,22 @@ module ibex_demo_system #(
       .unavailable_i     (1'b0),
 
       // bus device with debug memory (for execution-based debug)
-      .slave_req_i       (dbg_slave_req),
-      .slave_we_i        (dbg_slave_we),
-      .slave_addr_i      (dbg_slave_addr),
-      .slave_be_i        (dbg_slave_be),
-      .slave_wdata_i     (dbg_slave_wdata),
-      .slave_rdata_o     (dbg_slave_rdata),
+      .device_req_i      (dbg_device_req),
+      .device_we_i       (dbg_device_we),
+      .device_addr_i     (dbg_device_addr),
+      .device_be_i       (dbg_device_be),
+      .device_wdata_i    (dbg_device_wdata),
+      .device_rdata_o    (dbg_device_rdata),
 
       // bus host (for system bus accesses, SBA)
-      .master_req_o      (host_req[DbgHost]),
-      .master_add_o      (host_addr[DbgHost]),
-      .master_we_o       (host_we[DbgHost]),
-      .master_wdata_o    (host_wdata[DbgHost]),
-      .master_be_o       (host_be[DbgHost]),
-      .master_gnt_i      (host_gnt[DbgHost]),
-      .master_r_valid_i  (host_rvalid[DbgHost]),
-      .master_r_rdata_i  (host_rdata[DbgHost])
+      .host_req_o        (host_req[DbgHost]),
+      .host_add_o        (host_addr[DbgHost]),
+      .host_we_o         (host_we[DbgHost]),
+      .host_wdata_o      (host_wdata[DbgHost]),
+      .host_be_o         (host_be[DbgHost]),
+      .host_gnt_i        (host_gnt[DbgHost]),
+      .host_r_valid_i    (host_rvalid[DbgHost]),
+      .host_r_rdata_i    (host_rdata[DbgHost])
     );
   end else begin
     assign dm_debug_req = 1'b0;


### PR DESCRIPTION
We use host and device for our memory bus, we should use the same in our debug module top.