### PR TITLE
Add simulation wavefile to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 .venv/
 target/
+*.fst


### PR DESCRIPTION
These files are generated by Verilator when using the `-t` option. This is an example command that produces `sim.fst`:
```sh
./build/lowrisc_ibex_demo_system_0/sim-verilator/Vibex_demo_system -t --meminit=ram,$(pwd)/sw/c/build/demo/hello_world/demo
```