### PR TITLE
Add labels to generate blocks

### DIFF
--- a/rtl/system/gpio.sv
+++ b/rtl/system/gpio.sv
@@ -36,7 +36,7 @@ module gpio #(
   logic                gp_i_dbnc_rd_en_d, gp_i_dbnc_rd_en_q;
 
   // instantiate debouncers for all GP inputs
-  for (genvar i = 0; i < GpiWidth; i++) begin
+  for (genvar i = 0; i < GpiWidth; i++) begin : gen_debounce
     debounce #(
       .ClkCount(500)
     ) dbnc (
@@ -66,8 +66,8 @@ module gpio #(
   end
 
   // assign gp_o_d regarding to device_be_i and GpoWidth
-  for (genvar i_byte = 0; i_byte < 4; ++i_byte) begin : g_gp_o_d;
-    if (i_byte * 8 < GpoWidth) begin : g_gp_o_d_inner
+  for (genvar i_byte = 0; i_byte < 4; ++i_byte) begin : gen_gp_o_d;
+    if (i_byte * 8 < GpoWidth) begin : gen_gp_o_d_inner
       localparam int gpo_byte_end = (i_byte + 1) * 8 <= GpoWidth ? (i_byte + 1) * 8 : GpoWidth;
       assign gp_o_d[gpo_byte_end - 1 : i_byte * 8] =
         device_be_i[i_byte] ? device_wdata_i[gpo_byte_end - 1 : i_byte * 8] :

--- a/rtl/system/ibex_demo_system.sv
+++ b/rtl/system/ibex_demo_system.sv
@@ -442,7 +442,7 @@ module ibex_demo_system #(
     end
   end
 
-  if (DBG) begin : g_dm_top
+  if (DBG) begin : gen_dm_top
     dm_top #(
       .NrHarts ( 1 )
     ) u_dm_top (
@@ -472,7 +472,7 @@ module ibex_demo_system #(
       .host_r_valid_i    (host_rvalid[DbgHost]),
       .host_r_rdata_i    (host_rdata[DbgHost])
     );
-  end else begin
+  end else begin : gen_no_dm
     assign dm_debug_req = 1'b0;
     assign ndmreset_req = 1'b0;
   end

--- a/rtl/system/spi_host.sv
+++ b/rtl/system/spi_host.sv
@@ -115,7 +115,7 @@ module spi_host #(
   generate
     // If CPHA is HIGH, incoming data will be sampled on the falling edge while outgoing
     // data will get shifted out on the rising edge.
-    if (CPHA) begin
+    if (CPHA) begin : gen_cpha
       always_ff @(posedge clk_i or negedge rst_ni) begin
         if (!rst_ni) begin
           current_byte_q  <= '0;
@@ -136,7 +136,7 @@ module spi_host #(
       end
     // If CPHA is LOW, incoming data will be sampled on the rising edge while outgoing
     // data will get shifted out on the falling edge.
-    end else begin
+    end else begin : gen_no_cpha
       always_ff @(posedge clk_i or negedge rst_ni) begin
         if (!rst_ni) begin
           current_byte_q  <= '0;


### PR DESCRIPTION
This is to resolve `GENUNNAMED` warnings when using Verilator version 5.018

Closes: https://github.com/lowRISC/ibex-demo-system/issues/77