### PR TITLE
Make formatting of RTL files consistent

### DIFF
--- a/rtl/fpga/top_artya7.sv
+++ b/rtl/fpga/top_artya7.sv
@@ -3,45 +3,46 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // This is the top level SystemVerilog file that connects the IO on the board to the Ibex Demo System.
-module top_artya7 (
+module top_artya7 #(
+  parameter SRAMInitFile = ""
+) (
   // These inputs are defined in data/pins_artya7.xdc
-  input               IO_CLK,
-  input               IO_RST_N,
-  input  [ 3:0]       SW,
-  input  [ 3:0]       BTN,
-  output [ 3:0]       LED,
-  output [11:0]       RGB_LED,
-  output [ 3:0]       DISP_CTRL,
-  input               UART_RX,
-  output              UART_TX,
-  input               SPI_RX,
-  output              SPI_TX,
-  output              SPI_SCK
+  input         IO_CLK,
+  input         IO_RST_N,
+  input  [ 3:0] SW,
+  input  [ 3:0] BTN,
+  output [ 3:0] LED,
+  output [11:0] RGB_LED,
+  output [ 3:0] DISP_CTRL,
+  input         UART_RX,
+  output        UART_TX,
+  input         SPI_RX,
+  output        SPI_TX,
+  output        SPI_SCK
 );
-  parameter SRAMInitFile = "";
 
   logic clk_sys, rst_sys_n;
 
   // Instantiating the Ibex Demo System.
   ibex_demo_system #(
-    .GpiWidth(8),
-    .GpoWidth(8),
-    .PwmWidth(12),
-    .SRAMInitFile(SRAMInitFile)
+    .GpiWidth     ( 8            ),
+    .GpoWidth     ( 8            ),
+    .PwmWidth     ( 12           ),
+    .SRAMInitFile ( SRAMInitFile )
   ) u_ibex_demo_system (
     //input
-    .clk_sys_i(clk_sys),
+    .clk_sys_i (clk_sys),
     .rst_sys_ni(rst_sys_n),
-    .gp_i({SW, BTN}),
-    .uart_rx_i(UART_RX),
+    .gp_i      ({SW, BTN}),
+    .uart_rx_i (UART_RX),
 
     //output
-    .gp_o({LED, DISP_CTRL}),
-    .pwm_o(RGB_LED),
+    .gp_o     ({LED, DISP_CTRL}),
+    .pwm_o    (RGB_LED),
     .uart_tx_o(UART_TX),
 
-    .spi_rx_i(SPI_RX),
-    .spi_tx_o(SPI_TX),
+    .spi_rx_i (SPI_RX),
+    .spi_tx_o (SPI_TX),
     .spi_sck_o(SPI_SCK)
   );
 

--- a/rtl/system/debounce.sv
+++ b/rtl/system/debounce.sv
@@ -6,11 +6,14 @@
 // from the debounced output. If the input remains in that state for a certain
 // number of cycles (ClkCount) it is deemed stable and becomes the debounced
 // output. If the input changes (i.e. it is bouncing) we reset the counter.
+
+typedef int unsigned count_t;
+
 module debounce #(
-    parameter int unsigned ClkCount = 500
+    parameter count_t ClkCount = 500
 ) (
-    input logic clk_i,
-    input logic rst_ni,
+    input  logic clk_i,
+    input  logic rst_ni,
 
     input  logic btn_i,
     output logic btn_o
@@ -31,11 +34,9 @@ module debounce #(
     end
   end
 
-  /* verilator lint_off WIDTH */
-  assign btn_d = (cnt_q >= ClkCount) ? btn_i : btn_q;
+  assign btn_d = (count_t'(cnt_q) >= ClkCount) ? btn_i : btn_q;
   // Clear counter if button input equals stored value or if maximum counter value is reached,
   // otherwise increment counter.
-  /* verilator lint_off WIDTH */
-  assign cnt_d = (btn_i == btn_q || cnt_q >= ClkCount) ? '0 : cnt_q + 1;
+  assign cnt_d = (btn_i == btn_q || count_t'(cnt_q) >= ClkCount) ? '0 : cnt_q + 1;
 
 endmodule

--- a/rtl/system/gpio.sv
+++ b/rtl/system/gpio.sv
@@ -3,19 +3,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module gpio #(
-  GpiWidth = 8,
-  GpoWidth = 16
+  parameter int unsigned GpiWidth  = 8,
+  parameter int unsigned GpoWidth  = 16,
+  parameter int unsigned AddrWidth = 32,
+  parameter int unsigned DataWidth = 32,
+  parameter int unsigned RegAddr   = 12
 ) (
-  input  logic                clk_i,
-  input  logic                rst_ni,
+  input  logic clk_i,
+  input  logic rst_ni,
 
-  input  logic                device_req_i,
-  input  logic [31:0]         device_addr_i,
-  input  logic                device_we_i,
-  input  logic [ 3:0]         device_be_i,
-  input  logic [31:0]         device_wdata_i,
-  output logic                device_rvalid_o,
-  output logic [31:0]         device_rdata_o,
+  input  logic                 device_req_i,
+  input  logic [AddrWidth-1:0] device_addr_i,
+  input  logic                 device_we_i,
+  input  logic [3:0]           device_be_i,
+  input  logic [DataWidth-1:0] device_wdata_i,
+  output logic                 device_rvalid_o,
+  output logic [DataWidth-1:0] device_rdata_o,
 
   input  logic [GpiWidth-1:0] gp_i,
   output logic [GpoWidth-1:0] gp_o
@@ -25,17 +28,17 @@ module gpio #(
   localparam int unsigned GPIO_IN_REG = 32'h4;
   localparam int unsigned GPIO_IN_DBNC_REG = 32'h8;
 
-  logic [11:0] reg_addr;
+  logic [RegAddr-1:0] reg_addr;
 
   logic [2:0][GpiWidth-1:0] gp_i_q;
   logic [GpiWidth-1:0] gp_i_dbnc;
   logic [GpoWidth-1:0] gp_o_d;
 
-  logic                gp_o_wr_en;
-  logic                gp_i_rd_en_d, gp_i_rd_en_q;
-  logic                gp_i_dbnc_rd_en_d, gp_i_dbnc_rd_en_q;
+  logic gp_o_wr_en;
+  logic gp_i_rd_en_d, gp_i_rd_en_q;
+  logic gp_i_dbnc_rd_en_d, gp_i_dbnc_rd_en_q;
 
-  // instantiate debouncers for all GP inputs
+  // Instantiate debouncers for all GP inputs.
   for (genvar i = 0; i < GpiWidth; i++) begin : gen_debounce
     debounce #(
       .ClkCount(500)
@@ -65,36 +68,41 @@ module gpio #(
     end
   end
 
-  // assign gp_o_d regarding to device_be_i and GpoWidth
+  logic [3:0] unused_device_be;
+
+  // Assign gp_o_d regarding to device_be_i and GpoWidth.
   for (genvar i_byte = 0; i_byte < 4; ++i_byte) begin : gen_gp_o_d;
     if (i_byte * 8 < GpoWidth) begin : gen_gp_o_d_inner
       localparam int gpo_byte_end = (i_byte + 1) * 8 <= GpoWidth ? (i_byte + 1) * 8 : GpoWidth;
       assign gp_o_d[gpo_byte_end - 1 : i_byte * 8] =
         device_be_i[i_byte] ? device_wdata_i[gpo_byte_end - 1 : i_byte * 8] :
                               gp_o[gpo_byte_end - 1 : i_byte * 8];
+      assign unused_device_be[i_byte] = 0;
+    end else begin : gen_unused_device_be
+      assign unused_device_be[i_byte] = device_be_i[i_byte];
     end
   end
 
-  // decode write and read requests
-  assign reg_addr = device_addr_i[11:0];
-  assign gp_o_wr_en = device_req_i & device_we_i & (reg_addr == GPIO_OUT_REG[11:0]);
-  assign gp_i_rd_en_d = device_req_i & ~device_we_i & (reg_addr == GPIO_IN_REG[11:0]);
-  assign gp_i_dbnc_rd_en_d = device_req_i & ~device_we_i & (reg_addr == GPIO_IN_DBNC_REG[11:0]);
+  // Decode write and read requests.
+  assign reg_addr          = device_addr_i[RegAddr-1:0];
+  assign gp_o_wr_en        = device_req_i &  device_we_i & (reg_addr == GPIO_OUT_REG[RegAddr-1:0]);
+  assign gp_i_rd_en_d      = device_req_i & ~device_we_i & (reg_addr == GPIO_IN_REG[RegAddr-1:0]);
+  assign gp_i_dbnc_rd_en_d = device_req_i & ~device_we_i & (reg_addr == GPIO_IN_DBNC_REG[RegAddr-1:0]);
 
-  // assign device_rdata_o according to request type
+  // Assign device_rdata_o according to request type.
   always_comb begin
     if (gp_i_dbnc_rd_en_q)
-      device_rdata_o = {{(32 - GpiWidth){1'b0}}, gp_i_dbnc};
+      device_rdata_o = {{(DataWidth - GpiWidth){1'b0}}, gp_i_dbnc};
     else if (gp_i_rd_en_q)
-      device_rdata_o = {{(32 - GpiWidth){1'b0}}, gp_i_q[2]};
+      device_rdata_o = {{(DataWidth - GpiWidth){1'b0}}, gp_i_q[2]};
     else
-      device_rdata_o = {{(32 - GpoWidth){1'b0}}, gp_o};
+      device_rdata_o = {{(DataWidth - GpoWidth){1'b0}}, gp_o};
   end
 
-  logic unused_device_addr, unused_device_be, unused_device_wdata;
+  // Unused signals.
+  logic [AddrWidth-1-RegAddr:0]  unused_device_addr;
+  logic [DataWidth-1-GpoWidth:0] unused_device_wdata;
 
-  assign unused_device_addr = ^device_addr_i[31:10];
-  // TODO: Do this more neatly
-  assign unused_device_be = ^device_be_i;
-  assign unused_device_wdata = ^device_wdata_i[31:GpoWidth];
+  assign unused_device_addr  = device_addr_i[AddrWidth-1:RegAddr];
+  assign unused_device_wdata = device_wdata_i[DataWidth-1:GpoWidth];
 endmodule

--- a/rtl/system/ibex_demo_system.sv
+++ b/rtl/system/ibex_demo_system.sv
@@ -10,15 +10,15 @@
 // - UART for serial communication.
 // - Timer.
 // - Debug module.
-// - SPI for driving LCD screen
+// - SPI for driving LCD screen.
 module ibex_demo_system #(
   parameter int GpiWidth     = 8,
   parameter int GpoWidth     = 16,
   parameter int PwmWidth     = 12,
   parameter     SRAMInitFile = ""
 ) (
-  input logic                 clk_sys_i,
-  input logic                 rst_sys_ni,
+  input  logic clk_sys_i,
+  input  logic rst_sys_ni,
 
   input  logic [GpiWidth-1:0] gp_i,
   output logic [GpoWidth-1:0] gp_o,
@@ -37,8 +37,8 @@ module ibex_demo_system #(
   localparam logic [31:0] GPIO_START    = 32'h80000000;
   localparam logic [31:0] GPIO_MASK     = ~(GPIO_SIZE-1);
 
-  localparam logic [31:0] DEBUG_START   = 32'h1a110000;
   localparam logic [31:0] DEBUG_SIZE    = 64 * 1024; // 64 KiB
+  localparam logic [31:0] DEBUG_START   = 32'h1a110000;
   localparam logic [31:0] DEBUG_MASK    = ~(DEBUG_SIZE-1);
 
   localparam logic [31:0] UART_SIZE     =  4 * 1024; //  4 KiB
@@ -54,15 +54,15 @@ module ibex_demo_system #(
   localparam logic [31:0] PWM_MASK      = ~(PWM_SIZE-1);
   localparam int PwmCtrSize = 8;
 
-  parameter logic [31:0] SPI_SIZE       = 1 * 1024; // 1kB
+  parameter logic [31:0] SPI_SIZE       =  1 * 1024; //  1 KiB
   parameter logic [31:0] SPI_START      = 32'h80004000;
   parameter logic [31:0] SPI_MASK       = ~(SPI_SIZE-1);
 
-  parameter logic [31:0] SIM_CTRL_SIZE  = 1 * 1024; // 1kB
+  parameter logic [31:0] SIM_CTRL_SIZE  =  1 * 1024; //  1 KiB
   parameter logic [31:0] SIM_CTRL_START = 32'h20000;
   parameter logic [31:0] SIM_CTRL_MASK  = ~(SIM_CTRL_SIZE-1);
 
-  // debug functionality is optional
+  // Debug functionality is optional.
   localparam bit DBG = 1;
   localparam int unsigned DbgHwBreakNum = (DBG == 1) ?    2 :    0;
   localparam bit          DbgTriggerEn  = (DBG == 1) ? 1'b1 : 1'b0;
@@ -84,34 +84,34 @@ module ibex_demo_system #(
   } bus_device_e;
 
   localparam int NrDevices = DBG ? 8 : 7;
-  localparam int NrHosts = DBG ? 2 : 1;
+  localparam int NrHosts   = DBG ? 2 : 1;
 
-  // interrupts
+  // Interrupts.
   logic timer_irq;
   logic uart_irq;
 
-  // host and device signals
-  logic           host_req      [NrHosts];
-  logic           host_gnt      [NrHosts];
-  logic [31:0]    host_addr     [NrHosts];
-  logic           host_we       [NrHosts];
-  logic [ 3:0]    host_be       [NrHosts];
-  logic [31:0]    host_wdata    [NrHosts];
-  logic           host_rvalid   [NrHosts];
-  logic [31:0]    host_rdata    [NrHosts];
-  logic           host_err      [NrHosts];
+  // Host signals.
+  logic        host_req      [NrHosts];
+  logic        host_gnt      [NrHosts];
+  logic [31:0] host_addr     [NrHosts];
+  logic        host_we       [NrHosts];
+  logic [ 3:0] host_be       [NrHosts];
+  logic [31:0] host_wdata    [NrHosts];
+  logic        host_rvalid   [NrHosts];
+  logic [31:0] host_rdata    [NrHosts];
+  logic        host_err      [NrHosts];
 
-  // devices
-  logic           device_req    [NrDevices];
-  logic [31:0]    device_addr   [NrDevices];
-  logic           device_we     [NrDevices];
-  logic [ 3:0]    device_be     [NrDevices];
-  logic [31:0]    device_wdata  [NrDevices];
-  logic           device_rvalid [NrDevices];
-  logic [31:0]    device_rdata  [NrDevices];
-  logic           device_err    [NrDevices];
+  // Device signals.
+  logic        device_req    [NrDevices];
+  logic [31:0] device_addr   [NrDevices];
+  logic        device_we     [NrDevices];
+  logic [ 3:0] device_be     [NrDevices];
+  logic [31:0] device_wdata  [NrDevices];
+  logic        device_rvalid [NrDevices];
+  logic [31:0] device_rdata  [NrDevices];
+  logic        device_err    [NrDevices];
 
-  // Instruction fetch signals
+  // Instruction fetch signals.
   logic        core_instr_req;
   logic        core_instr_gnt;
   logic        core_instr_rvalid;
@@ -133,11 +133,11 @@ module ibex_demo_system #(
 
   // Internally generated resets cause IMPERFECTSCH warnings
   /* verilator lint_off IMPERFECTSCH */
-  logic        rst_core_n;
-  logic        ndmreset_req;
-  logic        dm_debug_req;
+  logic rst_core_n;
+  logic ndmreset_req;
+  logic dm_debug_req;
 
-  // Device address mapping
+  // Device address mapping.
   logic [31:0] cfg_device_addr_base [NrDevices];
   logic [31:0] cfg_device_addr_mask [NrDevices];
 
@@ -162,7 +162,7 @@ module ibex_demo_system #(
     assign device_err[DbgDev] = 1'b0;
   end
 
-  // Tie-off unused error signals
+  // Tie-off unused error signals.
   assign device_err[Ram]     = 1'b0;
   assign device_err[Gpio]    = 1'b0;
   assign device_err[Pwm]     = 1'b0;
@@ -176,27 +176,27 @@ module ibex_demo_system #(
     .DataWidth    ( 32        ),
     .AddressWidth ( 32        )
   ) u_bus (
-    .clk_i               (clk_sys_i),
-    .rst_ni              (rst_sys_ni),
+    .clk_i (clk_sys_i),
+    .rst_ni(rst_sys_ni),
 
-    .host_req_i          (host_req     ),
-    .host_gnt_o          (host_gnt     ),
-    .host_addr_i         (host_addr    ),
-    .host_we_i           (host_we      ),
-    .host_be_i           (host_be      ),
-    .host_wdata_i        (host_wdata   ),
-    .host_rvalid_o       (host_rvalid  ),
-    .host_rdata_o        (host_rdata   ),
-    .host_err_o          (host_err     ),
+    .host_req_i   (host_req     ),
+    .host_gnt_o   (host_gnt     ),
+    .host_addr_i  (host_addr    ),
+    .host_we_i    (host_we      ),
+    .host_be_i    (host_be      ),
+    .host_wdata_i (host_wdata   ),
+    .host_rvalid_o(host_rvalid  ),
+    .host_rdata_o (host_rdata   ),
+    .host_err_o   (host_err     ),
 
-    .device_req_o        (device_req   ),
-    .device_addr_o       (device_addr  ),
-    .device_we_o         (device_we    ),
-    .device_be_o         (device_be    ),
-    .device_wdata_o      (device_wdata ),
-    .device_rvalid_i     (device_rvalid),
-    .device_rdata_i      (device_rdata ),
-    .device_err_i        (device_err   ),
+    .device_req_o   (device_req   ),
+    .device_addr_o  (device_addr  ),
+    .device_we_o    (device_we    ),
+    .device_be_o    (device_be    ),
+    .device_wdata_o (device_wdata ),
+    .device_rvalid_i(device_rvalid),
+    .device_rdata_i (device_rdata ),
+    .device_err_i   (device_err   ),
 
     .cfg_device_addr_base,
     .cfg_device_addr_mask
@@ -241,8 +241,8 @@ module ibex_demo_system #(
     .scan_rst_ni(1'b1),
     .ram_cfg_i  ('b0),
 
-    .hart_id_i(32'b0),
-    // First instruction executed is at 0x0 + 0x80
+    .hart_id_i  (32'b0),
+    // First instruction executed is at 0x0 + 0x80.
     .boot_addr_i(32'h00100000),
 
     .instr_req_o       (core_instr_req),
@@ -291,32 +291,32 @@ module ibex_demo_system #(
       .Depth       ( MEM_SIZE / 4 ),
       .MemInitFile ( SRAMInitFile )
   ) u_ram (
-    .clk_i       (clk_sys_i),
-    .rst_ni      (rst_sys_ni),
+    .clk_i (clk_sys_i),
+    .rst_ni(rst_sys_ni),
 
-    .a_req_i     (device_req[Ram]),
-    .a_we_i      (device_we[Ram]),
-    .a_be_i      (device_be[Ram]),
-    .a_addr_i    (device_addr[Ram]),
-    .a_wdata_i   (device_wdata[Ram]),
-    .a_rvalid_o  (device_rvalid[Ram]),
-    .a_rdata_o   (device_rdata[Ram]),
+    .a_req_i   (device_req[Ram]),
+    .a_we_i    (device_we[Ram]),
+    .a_be_i    (device_be[Ram]),
+    .a_addr_i  (device_addr[Ram]),
+    .a_wdata_i (device_wdata[Ram]),
+    .a_rvalid_o(device_rvalid[Ram]),
+    .a_rdata_o (device_rdata[Ram]),
 
-    .b_req_i     (mem_instr_req),
-    .b_we_i      (1'b0),
-    .b_be_i      (4'b0),
-    .b_addr_i    (core_instr_addr),
-    .b_wdata_i   (32'b0),
-    .b_rvalid_o  (),
-    .b_rdata_o   (mem_instr_rdata)
+    .b_req_i   (mem_instr_req),
+    .b_we_i    (1'b0),
+    .b_be_i    (4'b0),
+    .b_addr_i  (core_instr_addr),
+    .b_wdata_i (32'b0),
+    .b_rvalid_o(),
+    .b_rdata_o (mem_instr_rdata)
   );
 
   gpio #(
     .GpiWidth ( GpiWidth ),
     .GpoWidth ( GpoWidth )
   ) u_gpio (
-    .clk_i          (clk_sys_i),
-    .rst_ni         (rst_sys_ni),
+    .clk_i (clk_sys_i),
+    .rst_ni(rst_sys_ni),
 
     .device_req_i   (device_req[Gpio]),
     .device_addr_i  (device_addr[Gpio]),
@@ -331,12 +331,12 @@ module ibex_demo_system #(
   );
 
   pwm_wrapper #(
-    .PwmWidth   ( PwmWidth   ),
-    .PwmCtrSize ( PwmCtrSize ),
-    .BusWidth   ( 32         )
+    .PwmWidth     ( PwmWidth   ),
+    .PwmCtrSize   ( PwmCtrSize ),
+    .BusAddrWidth ( 32         )
   ) u_pwm (
-    .clk_i          (clk_sys_i),
-    .rst_ni         (rst_sys_ni),
+    .clk_i (clk_sys_i),
+    .rst_ni(rst_sys_ni),
 
     .device_req_i   (device_req[Pwm]),
     .device_addr_i  (device_addr[Pwm]),
@@ -352,8 +352,8 @@ module ibex_demo_system #(
   uart #(
     .ClockFrequency ( 50_000_000 )
   ) u_uart (
-    .clk_i          (clk_sys_i),
-    .rst_ni         (rst_sys_ni),
+    .clk_i (clk_sys_i),
+    .rst_ni(rst_sys_ni),
 
     .device_req_i   (device_req[Uart]),
     .device_addr_i  (device_addr[Uart]),
@@ -369,9 +369,9 @@ module ibex_demo_system #(
   );
 
   spi_top #(
-    .ClockFrequency(50_000_000),
-    .CPOL(0),
-    .CPHA(1)
+    .ClockFrequency ( 50_000_000 ),
+    .CPOL           ( 0          ),
+    .CPHA           ( 1          )
   ) u_spi (
     .clk_i (clk_sys_i),
     .rst_ni(rst_sys_ni),
@@ -384,27 +384,27 @@ module ibex_demo_system #(
     .device_rvalid_o(device_rvalid[Spi]),
     .device_rdata_o (device_rdata[Spi]),
 
-    .spi_rx_i(spi_rx_i), // Data received from SPI device
-    .spi_tx_o(spi_tx_o), // Data transmitted to SPI device
-    .sck_o(spi_sck_o), // Serial clock pin
+    .spi_rx_i(spi_rx_i), // Data received from SPI device.
+    .spi_tx_o(spi_tx_o), // Data transmitted to SPI device.
+    .sck_o   (spi_sck_o), // Serial clock pin.
 
-    .byte_data_o() // unused
+    .byte_data_o() // Unused.
   );
 
   `ifdef VERILATOR
     simulator_ctrl #(
-      .LogName("ibex_demo_system.log")
+      .LogName ( "ibex_demo_system.log" )
     ) u_simulator_ctrl (
-      .clk_i     (clk_sys_i),
-      .rst_ni    (rst_sys_ni),
+      .clk_i (clk_sys_i),
+      .rst_ni(rst_sys_ni),
 
-      .req_i     (device_req[SimCtrl]),
-      .we_i      (device_we[SimCtrl]),
-      .be_i      (device_be[SimCtrl]),
-      .addr_i    (device_addr[SimCtrl]),
-      .wdata_i   (device_wdata[SimCtrl]),
-      .rvalid_o  (device_rvalid[SimCtrl]),
-      .rdata_o   (device_rdata[SimCtrl])
+      .req_i   (device_req[SimCtrl]),
+      .we_i    (device_we[SimCtrl]),
+      .be_i    (device_be[SimCtrl]),
+      .addr_i  (device_addr[SimCtrl]),
+      .wdata_i (device_wdata[SimCtrl]),
+      .rvalid_o(device_rvalid[SimCtrl]),
+      .rdata_o (device_rdata[SimCtrl])
     );
   `endif
 
@@ -412,8 +412,8 @@ module ibex_demo_system #(
     .DataWidth    ( 32 ),
     .AddressWidth ( 32 )
   ) u_timer (
-    .clk_i         (clk_sys_i),
-    .rst_ni        (rst_sys_ni),
+    .clk_i (clk_sys_i),
+    .rst_ni(rst_sys_ni),
 
     .timer_req_i   (device_req[Timer]),
     .timer_we_i    (device_we[Timer]),
@@ -446,31 +446,31 @@ module ibex_demo_system #(
     dm_top #(
       .NrHarts ( 1 )
     ) u_dm_top (
-      .clk_i             (clk_sys_i),
-      .rst_ni            (rst_sys_ni),
-      .testmode_i        (1'b0),
-      .ndmreset_o        (ndmreset_req),
-      .dmactive_o        (),
-      .debug_req_o       (dm_debug_req),
-      .unavailable_i     (1'b0),
+      .clk_i        (clk_sys_i),
+      .rst_ni       (rst_sys_ni),
+      .testmode_i   (1'b0),
+      .ndmreset_o   (ndmreset_req),
+      .dmactive_o   (),
+      .debug_req_o  (dm_debug_req),
+      .unavailable_i(1'b0),
 
-      // bus device with debug memory (for execution-based debug)
-      .device_req_i      (dbg_device_req),
-      .device_we_i       (dbg_device_we),
-      .device_addr_i     (dbg_device_addr),
-      .device_be_i       (dbg_device_be),
-      .device_wdata_i    (dbg_device_wdata),
-      .device_rdata_o    (dbg_device_rdata),
+      // Bus device with debug memory (for execution-based debug).
+      .device_req_i  (dbg_device_req),
+      .device_we_i   (dbg_device_we),
+      .device_addr_i (dbg_device_addr),
+      .device_be_i   (dbg_device_be),
+      .device_wdata_i(dbg_device_wdata),
+      .device_rdata_o(dbg_device_rdata),
 
-      // bus host (for system bus accesses, SBA)
-      .host_req_o        (host_req[DbgHost]),
-      .host_add_o        (host_addr[DbgHost]),
-      .host_we_o         (host_we[DbgHost]),
-      .host_wdata_o      (host_wdata[DbgHost]),
-      .host_be_o         (host_be[DbgHost]),
-      .host_gnt_i        (host_gnt[DbgHost]),
-      .host_r_valid_i    (host_rvalid[DbgHost]),
-      .host_r_rdata_i    (host_rdata[DbgHost])
+      // Bus host (for system bus accesses, SBA).
+      .host_req_o    (host_req[DbgHost]),
+      .host_add_o    (host_addr[DbgHost]),
+      .host_we_o     (host_we[DbgHost]),
+      .host_wdata_o  (host_wdata[DbgHost]),
+      .host_be_o     (host_be[DbgHost]),
+      .host_gnt_i    (host_gnt[DbgHost]),
+      .host_r_valid_i(host_rvalid[DbgHost]),
+      .host_r_rdata_i(host_rdata[DbgHost])
     );
   end else begin : gen_no_dm
     assign dm_debug_req = 1'b0;

--- a/rtl/system/pwm.sv
+++ b/rtl/system/pwm.sv
@@ -5,14 +5,14 @@
 module pwm #(
   parameter int CtrSize = 8
 ) (
-  input  logic               clk_i,
-  input  logic               rst_ni,
+  input  logic clk_i,
+  input  logic rst_ni,
 
   // To produce an always-on signal, you will need to make pulse_width_i > max_counter_i.
   input  logic [CtrSize-1:0] pulse_width_i,
   input  logic [CtrSize-1:0] max_counter_i,
 
-  output logic               modulated_o
+  output logic modulated_o
 );
   logic [CtrSize-1:0] counter;
 

--- a/rtl/system/pwm_wrapper.sv
+++ b/rtl/system/pwm_wrapper.sv
@@ -4,28 +4,29 @@
 
 // This wrapper instantiates a series of PWMs and distributes requests from the device bus.
 module pwm_wrapper #(
-  parameter int PwmWidth   = 12,
-  parameter int PwmCtrSize = 8,
-  parameter int BusWidth   = 32
+  parameter int PwmWidth     = 12,
+  parameter int PwmCtrSize   = 8,
+  parameter int BusAddrWidth = 32,
+  parameter int BusDataWidth = 32
 ) (
-  input  logic                clk_i,
-  input  logic                rst_ni,
+  input  logic clk_i,
+  input  logic rst_ni,
 
   // IO for device bus.
-  input  logic                device_req_i,
-  input  logic [BusWidth-1:0] device_addr_i,
-  input  logic                device_we_i,
-  input  logic [         3:0] device_be_i,
-  input  logic [BusWidth-1:0] device_wdata_i,
-  output logic                device_rvalid_o,
-  output logic [BusWidth-1:0] device_rdata_o,
+  input  logic                    device_req_i,
+  input  logic [BusAddrWidth-1:0] device_addr_i,
+  input  logic                    device_we_i,
+  input  logic [3:0]              device_be_i,
+  input  logic [BusDataWidth-1:0] device_wdata_i,
+  output logic                    device_rvalid_o,
+  output logic [BusDataWidth-1:0] device_rdata_o,
 
   // Collected output of all PWMs.
   output logic [PwmWidth-1:0] pwm_o
 );
 
   localparam int unsigned AddrWidth = 10;
-  localparam int unsigned PwmIdxOffset = $clog2(BusWidth / 8) + 1;
+  localparam int unsigned PwmIdxOffset = $clog2(BusAddrWidth / 8) + 1;
   localparam int unsigned PwmIdxWidth = AddrWidth - PwmIdxOffset;
 
   // Generate PwmWidth number of PWMs.

--- a/rtl/system/spi_host.sv
+++ b/rtl/system/spi_host.sv
@@ -4,9 +4,9 @@
 
 module spi_host #(
   parameter int unsigned ClockFrequency = 50_000_000,
-  parameter int unsigned BaudRate = 12_500_000,
-  parameter bit CPOL = 0,
-  parameter bit CPHA = 0
+  parameter int unsigned BaudRate       = 12_500_000,
+  parameter bit CPOL                    = 0,
+  parameter bit CPHA                    = 0
 )(
     input clk_i,
     input rst_ni,

--- a/rtl/system/spi_top.sv
+++ b/rtl/system/spi_top.sv
@@ -4,23 +4,23 @@
 
 module spi_top #(
   parameter int unsigned ClockFrequency = 50_000_000,
-  parameter int unsigned BaudRate = 12_500_000,
-  parameter CPOL = 0,
-  parameter CPHA = 0
+  parameter int unsigned BaudRate       = 12_500_000,
+  parameter bit CPOL                    = 0,
+  parameter bit CPHA                    = 0,
+  parameter int unsigned AddrWidth      = 32,
+  parameter int unsigned DataWidth      = 32,
+  parameter int unsigned RegAddr        = 12
 ) (
-    input logic clk_i,
-    input logic rst_ni,
+    input  logic clk_i,
+    input  logic rst_ni,
 
-    input  logic        device_req_i,
-  /* verilator lint_off UNUSED */
-    input  logic [31:0] device_addr_i,
-    input  logic        device_we_i,
-  /* verilator lint_off UNUSED */
-    input  logic [3:0]  device_be_i,
-  /* verilator lint_off UNUSED */
-    input  logic [31:0] device_wdata_i,
-    output logic        device_rvalid_o,
-    output logic [31:0] device_rdata_o,
+    input  logic                 device_req_i,
+    input  logic [AddrWidth-1:0] device_addr_i,
+    input  logic                 device_we_i,
+    input  logic [3:0]           device_be_i,
+    input  logic [DataWidth-1:0] device_wdata_i,
+    output logic                 device_rvalid_o,
+    output logic [DataWidth-1:0] device_rdata_o,
 
     input  logic spi_rx_i,
     output logic spi_tx_o,
@@ -29,13 +29,13 @@ module spi_top #(
     output logic [7:0] byte_data_o
   );
 
-  localparam logic [11:0] SPI_TX_REG = 12'h0;
-  localparam logic [11:0] SPI_STATUS_REG = 12'h4;
+  localparam logic [RegAddr-1:0] SpiTxReg     = RegAddr'('h0);
+  localparam logic [RegAddr-1:0] SpiStatusReg = RegAddr'('h4);
 
-  logic [11:0] reg_addr;
+  logic [RegAddr-1:0] reg_addr;
 
   // Status register read enable
-  logic        read_status_q, read_status_d;
+  logic read_status_q, read_status_d;
 
   // Edge detection for popping FIFO elements.
   logic next_tx_byte_d, next_tx_byte_q;
@@ -59,16 +59,16 @@ module spi_top #(
   assign tx_fifo_rready = next_tx_byte_d && ~next_tx_byte_q;
 
   // We have 1kB space for SPI related registers, ignore top address bits.
-  assign reg_addr = device_addr_i[11:0];
+  assign reg_addr = device_addr_i[RegAddr-1:0];
 
   // FIFO depth signal gives the current valid elements in the FIFO, zero means it's empty.
   // This will be used in software to indicate whenever we see an empty
   assign tx_fifo_empty = (tx_fifo_depth == 0);
 
-  // FIFO push happens when software writes to SPI_TX_REG
-  assign tx_fifo_wvalid = (device_req_i & (reg_addr == SPI_TX_REG) & device_we_i);
+  // FIFO push happens when software writes to SpiTxReg
+  assign tx_fifo_wvalid = (device_req_i & (reg_addr == SpiTxReg) & device_we_i & device_be_i[0]);
 
-  assign read_status_d = (device_req_i & (reg_addr == SPI_STATUS_REG) & ~device_we_i);
+  assign read_status_d = (device_req_i & (reg_addr == SpiStatusReg) & ~device_we_i);
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       read_status_q  <= 0;
@@ -76,47 +76,56 @@ module spi_top #(
       read_status_q  <= read_status_d;
     end
   end
-  assign device_rdata_o = read_status_q ? {30'b0, tx_fifo_empty, tx_fifo_full} : 32'b0;
+  assign device_rdata_o = read_status_q ? {(DataWidth-2)'('0), tx_fifo_empty, tx_fifo_full} : DataWidth'('0);
 
   prim_fifo_sync #(
-    .Width(8),
-    .Pass(1'b0),
-    .Depth(127)
+    .Width ( 8    ),
+    .Pass  ( 1'b0 ),
+    .Depth ( 127  )
   ) u_tx_fifo (
     .clk_i (clk_i),
     .rst_ni,
-    .clr_i(1'b0),
+    .clr_i (1'b0),
 
     .wvalid_i(tx_fifo_wvalid), // FIFO Push
     .wready_o(),
-    .wdata_i(device_wdata_i[7:0]),
+    .wdata_i (device_wdata_i[7:0]),
 
     .rvalid_o(tx_fifo_rvalid),
     .rready_i(tx_fifo_rready), // FIFO Pop
-    .rdata_o(tx_fifo_rdata),
+    .rdata_o (tx_fifo_rdata),
 
-    .full_o(tx_fifo_full),
+    .full_o (tx_fifo_full),
     .depth_o(tx_fifo_depth),
     .err_o() // Unused
   );
 
   spi_host #(
-    .ClockFrequency(ClockFrequency),
-    .BaudRate(BaudRate),
-    .CPOL(CPOL),
-    .CPHA(CPHA)
+    .ClockFrequency ( ClockFrequency ),
+    .BaudRate       ( BaudRate       ),
+    .CPOL           ( CPOL           ),
+    .CPHA           ( CPHA           )
   ) u_spi_host (
     .clk_i (clk_i),
     .rst_ni(rst_ni),
 
     .spi_rx_i(spi_rx_i), // Data received from SPI device
     .spi_tx_o(spi_tx_o), // Data transmitted to SPI device
-    .sck_o(sck_o), // Serial clock output
+    .sck_o   (sck_o), // Serial clock output
 
-    .start_i(tx_fifo_rvalid), // Starts SPI as long as we have a valid FIFO data.
-    .byte_data_i(tx_fifo_rdata), // 8-bit data, from FIFO possibly
-    .byte_data_o(byte_data_o),
+    .start_i       (tx_fifo_rvalid), // Starts SPI as long as we have a valid FIFO data.
+    .byte_data_i   (tx_fifo_rdata), // 8-bit data, from FIFO possibly
+    .byte_data_o   (byte_data_o),
     .next_tx_byte_o(next_tx_byte_d) // requests new byte
   );
+
+  // Unused signals.
+  logic [AddrWidth-1-RegAddr:0] unused_device_addr;
+  logic [3:1]                   unused_device_be;
+  logic [DataWidth-1-8:0]       unused_device_wdata;
+
+  assign unused_device_addr  = device_addr_i[AddrWidth-1:RegAddr];
+  assign unused_device_be    = device_be_i[3:1];
+  assign unused_device_wdata = device_wdata_i[DataWidth-1:8];
 
 endmodule


### PR DESCRIPTION
These fixes include:
- Indentation of parameter lists.
- Indentation of input/output lists.
- Indentation of variable declaration.
- Making comments full sentences ending in period.
- Adding address and data width parameters.
- Turn Verilator lints back on and resolve width and unused warnings.
- Use ANSI style of parameter declarations.