### PR TITLE
Set linker script from build.rs file

### DIFF
--- a/sw/rust/.cargo/config.toml
+++ b/sw/rust/.cargo/config.toml
@@ -7,9 +7,6 @@ target = "riscv32imc-unknown-none-elf"
 
 [target.riscv32imc-unknown-none-elf]
 runner = "../../util/load_demo_system.sh run"
-rustflags = [
-  "-C", "link-arg=-T../common/link.ld",
-]
 
 [unstable]
 build-std = ["core"]

--- a/sw/rust/Cargo.toml
+++ b/sw/rust/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "demo/lcd_hal",
     "demo/pwm_hal",
 ]
+resolver = "2"
 
 [profile.release]
 debug = true

--- a/sw/rust/Cargo.toml
+++ b/sw/rust/Cargo.toml
@@ -16,3 +16,9 @@ resolver = "2"
 
 [profile.release]
 debug = true
+
+[profile.dev]
+opt-level = 1
+
+[profile.dev.package.'*']
+opt-level = 2

--- a/sw/rust/build.rs
+++ b/sw/rust/build.rs
@@ -1,0 +1,42 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This Cargo build script locates and uses the `link.ld` linker script.
+//!
+//! This build script can be used by a crate from its Cargo.toml:
+//!
+//! ```toml
+//! [package]
+//! ...
+//! build = "../path/to/build.rs"
+//! ```
+//!
+//! Build scripts are run with their working directory as the root of the
+//! crate being built. We must find the path to the Cargo workspace in order
+//! to get the correct path to the `link.ld` script.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() {
+    // Ask Cargo for the path of the workspace.
+    let workspace_path = Command::new(env!("CARGO"))
+        .arg("locate-project")
+        .arg("--workspace")
+        .arg("--message-format=plain")
+        .output()
+        .expect("failed to locate project using cargo")
+        .stdout;
+    let workspace_path = std::str::from_utf8(&workspace_path).expect("path to workspace not UTF-8");
+    let workspace_path = PathBuf::from(workspace_path);
+    let workspace_path = workspace_path.parent().expect("failed to get parent");
+
+    // Find the path of the linker script relative to the workspace.
+    let linker_script_path = workspace_path.join("../common/link.ld");
+    let linker_script_path = linker_script_path.display();
+
+    // Use the linker script and rebuild crates if it changes.
+    println!("cargo:rerun-if-changed={linker_script_path}");
+    println!("cargo:rustc-link-arg=-T{linker_script_path}");
+}

--- a/sw/rust/demo/hello_world/Cargo.toml
+++ b/sw/rust/demo/hello_world/Cargo.toml
@@ -6,6 +6,8 @@
 name = "hello_world"
 version = "0.1.0"
 edition = "2021"
+# This build script configures the linker script to use.
+build = "../../build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/sw/rust/demo/lcd_hal/Cargo.toml
+++ b/sw/rust/demo/lcd_hal/Cargo.toml
@@ -6,6 +6,8 @@
 name = "lcd_hal"
 version = "0.1.0"
 edition = "2021"
+# This build script configures the linker script to use.
+build = "../../build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/sw/rust/demo/led/Cargo.toml
+++ b/sw/rust/demo/led/Cargo.toml
@@ -6,6 +6,8 @@
 name = "led"
 version = "0.1.0"
 edition = "2021"
+# This build script configures the linker script to use.
+build = "../../build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/sw/rust/demo/led_hal/Cargo.toml
+++ b/sw/rust/demo/led_hal/Cargo.toml
@@ -6,6 +6,8 @@
 name = "led_hal"
 version = "0.1.0"
 edition = "2021"
+# This build script configures the linker script to use.
+build = "../../build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/sw/rust/demo/pwm_hal/Cargo.toml
+++ b/sw/rust/demo/pwm_hal/Cargo.toml
@@ -6,6 +6,8 @@
 name = "pwm_hal"
 version = "0.1.0"
 edition = "2021"
+# This build script configures the linker script to use.
+build = "../../build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This has two advantages:

1. It adds a `cargo:rerun-if-changed` command to ensure we rebuild crates if the linker script changes.
2. The path to the linker script does not depend on the directory that Cargo is executed from, so `cargo build` can be done from anywhere.