### PR TITLE
Integrated OpenTitan's DPI based Virtual UART into the verilator test bench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 build/
 .venv/
+__pycache__/
 target/
 *.fst
+*.log
+*.csv

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ in `ibex_demo_system.core`
 The Demo System simulator binary can be built via FuseSoC. From the Ibex
 repository root run:
 
-```
+```sh
 fusesoc --cores-root=. run --target=sim --tool=verilator --setup --build lowrisc:ibex:demo_system
 ```
 
@@ -435,14 +435,13 @@ built as described above. Use `./sw/c/build/demo/hello_world/demo` to run the `d
 binary.
 
 Run from the repository root run:
-```
+```sh
 # For example :
-./build/lowrisc_ibex_demo_system_0/sim-verilator/Vibex_demo_system \
+./build/lowrisc_ibex_demo_system_0/sim-verilator/Vtop_verilator \
   --meminit=ram,./sw/c/build/demo/hello_world/demo
 
 # You need to substitute the <sw_elf_file> for a binary we have build above.
-./build/lowrisc_ibex_demo_system_0/sim-verilator/Vibex_demo_system [-t] --meminit=ram,<sw_elf_file>
-
+./build/lowrisc_ibex_demo_system_0/sim-verilator/Vtop_verilator [-t] --meminit=ram,<sw_elf_file>
 ```
 
 Pass `-t` to get an FST trace of execution that can be viewed with

--- a/dv/verilator/demo_system_verilator_lint.vlt
+++ b/dv/verilator/demo_system_verilator_lint.vlt
@@ -27,5 +27,7 @@ lint_off -rule UNUSED -file "*ibex_register_file_fpga*"
 lint_off -rule UNOPTFLAT -file "*/lowrisc_prim_fifo_0/rtl/prim_fifo_async_simple.sv"
 lint_off -rule WIDTH -file "*pulp_riscv_dbg/src/dm_mem.sv"
 
-lint_off -rule UNDRIVEN -file "*ibex_register_file_fpga.sv"
 lint_off -rule IMPERFECTSCH -file "*prim_flop_2sync.sv"
+
+lint_off -rule WIDTH  -file "*uartdpi.sv"
+lint_off -rule UNUSED -file "*uartdpi.sv"

--- a/dv/verilator/ibex_demo_system.cc
+++ b/dv/verilator/ibex_demo_system.cc
@@ -6,7 +6,7 @@
 #include <fstream>
 #include <iostream>
 
-#include "Vibex_demo_system__Syms.h"
+#include "Vtop_verilator__Syms.h"
 #include "ibex_pcounts.h"
 #include "ibex_demo_system.h"
 #include "verilated_toplevel.h"
@@ -36,7 +36,7 @@ int DemoSystem::Main(int argc, char **argv) {
 int DemoSystem::Setup(int argc, char **argv, bool &exit_app) {
   VerilatorSimCtrl &simctrl = VerilatorSimCtrl::GetInstance();
 
-  simctrl.SetTop(&_top, &_top.clk_sys_i, &_top.rst_sys_ni,
+  simctrl.SetTop(&_top, &_top.clk_i, &_top.rst_ni,
                  VerilatorSimCtrlFlags::ResetPolarityNegative);
 
   _memutil.RegisterMemoryArea("ram", 0x0, &_ram);
@@ -66,7 +66,7 @@ bool DemoSystem::Finish() {
   // Set the scope to the root scope, the ibex_pcount_string function otherwise
   // doesn't know the scope itself. Could be moved to ibex_pcount_string, but
   // would require a way to set the scope name from here, similar to MemUtil.
-  svSetScope(svGetScopeFromName("TOP.ibex_demo_system"));
+  svSetScope(svGetScopeFromName("TOP.top_verilator.u_ibex_demo_system"));
 
   std::cout << "\nPerformance Counters" << std::endl
             << "====================" << std::endl;

--- a/dv/verilator/ibex_demo_system.h
+++ b/dv/verilator/ibex_demo_system.h
@@ -13,7 +13,7 @@ class DemoSystem {
 
 
  protected:
-  ibex_demo_system _top;
+  top_verilator _top;
   VerilatorMemUtil _memutil;
   MemArea _ram;
 

--- a/dv/verilator/ibex_demo_system_main.cc
+++ b/dv/verilator/ibex_demo_system_main.cc
@@ -6,7 +6,7 @@
 
 int main(int argc, char **argv) {
   DemoSystem demo_system(
-      "TOP.ibex_demo_system.u_ram.u_ram.gen_generic.u_impl_generic",
+      "TOP.top_verilator.u_ibex_demo_system.u_ram.u_ram.gen_generic.u_impl_generic",
       1024 * 1024);
 
   return demo_system.Main(argc, argv);

--- a/dv/verilator/top_verilator.sv
+++ b/dv/verilator/top_verilator.sv
@@ -1,0 +1,57 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This is the top level that connects the demo system to the virtual devices.
+module top_verilator (input logic clk_i, rst_ni);
+
+  localparam ClockFrequency = 50_000_000;
+  localparam BaudRate       = 115_200;
+
+  logic uart_sys_rx, uart_sys_tx;
+
+  // Instantiating the Ibex Demo System.
+  ibex_demo_system #(
+    .GpiWidth       ( 8                   ),
+    .GpoWidth       ( 16                  ),
+    .PwmWidth       ( 12                  ),
+    .ClockFrequency ( ClockFrequency      ),
+    .BaudRate       ( BaudRate            ),
+    .RegFile        ( ibex_pkg::RegFileFF )
+  ) u_ibex_demo_system (
+    //Input
+    .clk_sys_i (clk_i),
+    .rst_sys_ni(rst_ni),
+    .uart_rx_i (uart_sys_rx),
+
+    //Output
+    .uart_tx_o(uart_sys_tx),
+
+    // tie off JTAG
+    .trst_ni(1'b1),
+    .tms_i  (1'b0),
+    .tck_i  (1'b0),
+    .td_i   (1'b0),
+    .td_o   (    ),
+
+    // Remaining IO
+    .gp_i      (0),
+    .gp_o      ( ),
+    .pwm_o     ( ),
+    .spi_rx_i  (0),
+    .spi_tx_o  ( ),
+    .spi_sck_o ( )
+  );
+
+  // Virtual UART
+  uartdpi #(
+    .BAUD(BaudRate),
+    .FREQ(ClockFrequency)
+  ) u_uartdpi (
+    .clk_i,
+    .rst_ni,
+    .active (1'b1       ),
+    .tx_o   (uart_sys_rx),
+    .rx_i   (uart_sys_tx)
+  );
+endmodule

--- a/flake.nix
+++ b/flake.nix
@@ -90,7 +90,7 @@
           Build ibex simulation verilator model :
               fusesoc --cores-root=. run --target=sim --tool=verilator --setup --build lowrisc:ibex:demo_system
           Run ibex simulator verilator model :
-              ./build/lowrisc_ibex_demo_system_0/sim-verilator/Vibex_demo_system -t \
+              ./build/lowrisc_ibex_demo_system_0/sim-verilator/Vtop_verilator -t \
                 --meminit=ram,sw/c/build/demo/hello_world/demo
           Build ibex-demo-system FPGA bitstream for Arty-A7 :
               fusesoc --cores-root=. run --target=synth --setup --build lowrisc:ibex:demo_system

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,6 @@
             cmake
             openocd
             screen
-            verilator
             # Needed to compile verilator generated files
             gcc
 
@@ -66,6 +65,7 @@
           ++ (with lowrisc-nix.packages.${system}; [
             spike-ibex-cosim
             lowrisc-toolchain-gcc-rv32imcb
+            verilator_ot
           ]);
         shellHook = ''
           # FIXME This works on Ubuntu, may not on other distros. FIXME

--- a/ibex_demo_system.core
+++ b/ibex_demo_system.core
@@ -49,7 +49,10 @@ filesets:
       - lowrisc:dv_verilator:memutil_verilator
       - lowrisc:dv_verilator:simutil_verilator
       - lowrisc:dv_verilator:ibex_pcounts
+      - lowrisc:dv_dpi_c:uartdpi:0.1
+      - lowrisc:dv_dpi_sv:uartdpi:0.1
     files:
+      - dv/verilator/top_verilator.sv: { file_type: systemVerilogSource }
       - dv/verilator/ibex_demo_system.cc: { file_type: cppSource }
       - dv/verilator/ibex_demo_system.h:  { file_type: cppSource, is_include_file: true}
       - dv/verilator/ibex_demo_system_main.cc: { file_type: cppSource }
@@ -163,7 +166,7 @@ targets:
     default_tool: verilator
     filesets_append:
       - files_verilator
-    toplevel: ibex_demo_system
+    toplevel: top_verilator
     tools:
       verilator:
         mode: cc
@@ -175,7 +178,7 @@ targets:
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=ibex_demo_system"'
+          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=top_verilator"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
           - "-Wwarn-IMPERFECTSCH"

--- a/rtl/system/ibex_demo_system.sv
+++ b/rtl/system/ibex_demo_system.sv
@@ -12,10 +12,13 @@
 // - Debug module.
 // - SPI for driving LCD screen.
 module ibex_demo_system #(
-  parameter int GpiWidth     = 8,
-  parameter int GpoWidth     = 16,
-  parameter int PwmWidth     = 12,
-  parameter     SRAMInitFile = ""
+  parameter int                 GpiWidth       = 8,
+  parameter int                 GpoWidth       = 16,
+  parameter int                 PwmWidth       = 12,
+  parameter int unsigned        ClockFrequency = 50_000_000,
+  parameter int unsigned        BaudRate       = 115_200,
+  parameter ibex_pkg::regfile_e RegFile        = ibex_pkg::RegFileFPGA,
+  parameter                     SRAMInitFile   = ""
 ) (
   input  logic clk_sys_i,
   input  logic rst_sys_ni,
@@ -231,7 +234,7 @@ module ibex_demo_system #(
   assign rst_core_n = rst_sys_ni & ~ndmreset_req;
 
   ibex_top #(
-    .RegFile         ( ibex_pkg::RegFileFPGA                   ),
+    .RegFile         ( RegFile                                 ),
     .MHPMCounterNum  ( 10                                      ),
     .RV32M           ( ibex_pkg::RV32MFast                     ),
     .RV32B           ( ibex_pkg::RV32BNone                     ),
@@ -356,7 +359,8 @@ module ibex_demo_system #(
   );
 
   uart #(
-    .ClockFrequency ( 50_000_000 )
+    .ClockFrequency ( ClockFrequency ),
+    .BaudRate       ( BaudRate       )
   ) u_uart (
     .clk_i (clk_sys_i),
     .rst_ni(rst_sys_ni),
@@ -375,7 +379,7 @@ module ibex_demo_system #(
   );
 
   spi_top #(
-    .ClockFrequency ( 50_000_000 ),
+    .ClockFrequency ( ClockFrequency ),
     .CPOL           ( 0          ),
     .CPHA           ( 1          )
   ) u_spi (

--- a/vendor/lowrisc_ip.vendor.hjson
+++ b/vendor/lowrisc_ip.vendor.hjson
@@ -16,5 +16,7 @@
         {from: "hw/ip/prim_xilinx",    to: "ip/prim_xilinx"},
 
         {from: "hw/lint",              to: "lint"},
+
+        {from: "hw/dv/dpi/uartdpi",    to: "dv/dpi/uartdpi"},
     ]
 }

--- a/vendor/lowrisc_ip/dv/dpi/uartdpi/uartdpi.c
+++ b/vendor/lowrisc_ip/dv/dpi/uartdpi/uartdpi.c
@@ -1,0 +1,140 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "uartdpi.h"
+
+#ifdef __linux__
+#include <pty.h>
+#elif __APPLE__
+#include <util.h>
+#endif
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+// This keeps the necessary uart state.
+struct uartdpi_ctx {
+  char ptyname[64];
+  int host;
+  int device;
+  char tmp_read;
+  FILE *log_file;
+};
+
+void *uartdpi_create(const char *name, const char *log_file_path) {
+  struct uartdpi_ctx *ctx =
+      (struct uartdpi_ctx *)malloc(sizeof(struct uartdpi_ctx));
+  assert(ctx);
+
+  int rv;
+
+  // Initialize UART pseudo-terminal
+  struct termios tty;
+  cfmakeraw(&tty);
+
+  rv = openpty(&ctx->host, &ctx->device, 0, &tty, 0);
+  assert(rv != -1);
+
+  rv = ttyname_r(ctx->device, ctx->ptyname, 64);
+  assert(rv == 0 && "ttyname_r failed");
+
+  int cur_flags = fcntl(ctx->host, F_GETFL, 0);
+  assert(cur_flags != -1 && "Unable to read current flags.");
+  int new_flags = fcntl(ctx->host, F_SETFL, cur_flags | O_NONBLOCK);
+  assert(new_flags != -1 && "Unable to set FD flags");
+
+  printf(
+      "\n"
+      "UART: Created %s for %s. Connect to it with any terminal program, e.g.\n"
+      "$ screen %s\n",
+      ctx->ptyname, name, ctx->ptyname);
+
+  // Open log file (if requested)
+  ctx->log_file = NULL;
+  bool write_log_file = strlen(log_file_path) != 0;
+  if (write_log_file) {
+    if (strcmp(log_file_path, "-") == 0) {
+      ctx->log_file = stdout;
+      printf("UART: Additionally writing all UART output to STDOUT.\n");
+
+    } else {
+      FILE *log_file;
+      log_file = fopen(log_file_path, "w");
+      if (!log_file) {
+        fprintf(stderr, "UART: Unable to open log file at %s: %s\n",
+                log_file_path, strerror(errno));
+      } else {
+        // Switch log file output to line buffering to ensure lines written to
+        // the UART device show up in the log file as soon as a newline
+        // character is written.
+        rv = setvbuf(log_file, NULL, _IOLBF, 0);
+        assert(rv == 0);
+
+        ctx->log_file = log_file;
+        printf("UART: Additionally writing all UART output to '%s'.\n",
+               log_file_path);
+      }
+    }
+  }
+
+  return (void *)ctx;
+}
+
+void uartdpi_close(void *ctx_void) {
+  struct uartdpi_ctx *ctx = (struct uartdpi_ctx *)ctx_void;
+  if (!ctx) {
+    return;
+  }
+
+  close(ctx->host);
+  close(ctx->device);
+
+  if (ctx->log_file) {
+    // Always ensure the log file is flushed (most important when writing
+    // to STDOUT)
+    fflush(ctx->log_file);
+    if (ctx->log_file != stdout) {
+      fclose(ctx->log_file);
+    }
+  }
+
+  free(ctx);
+}
+
+int uartdpi_can_read(void *ctx_void) {
+  struct uartdpi_ctx *ctx = (struct uartdpi_ctx *)ctx_void;
+  if (ctx == NULL) {
+    return 0;
+  }
+  int rv = read(ctx->host, &ctx->tmp_read, 1);
+  return (rv == 1);
+}
+
+char uartdpi_read(void *ctx_void) {
+  struct uartdpi_ctx *ctx = (struct uartdpi_ctx *)ctx_void;
+
+  return ctx->tmp_read;
+}
+
+void uartdpi_write(void *ctx_void, char c) {
+  int rv;
+  struct uartdpi_ctx *ctx = (struct uartdpi_ctx *)ctx_void;
+  if (ctx == NULL) {
+    return;
+  }
+
+  rv = write(ctx->host, &c, 1);
+  assert(rv == 1 && "Write to pseudo-terminal failed.");
+
+  if (ctx->log_file) {
+    rv = fwrite(&c, sizeof(char), 1, ctx->log_file);
+    assert(rv == 1 && "Write to log file failed.");
+  }
+}

--- a/vendor/lowrisc_ip/dv/dpi/uartdpi/uartdpi.core
+++ b/vendor/lowrisc_ip/dv/dpi/uartdpi/uartdpi.core
@@ -1,0 +1,18 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv_dpi_c:uartdpi:0.1"
+description: "UART-DPI C code"
+
+filesets:
+  files_c:
+    files:
+      - uartdpi.c: { file_type: cppSource }
+      - uartdpi.h: { file_type: cppSource, is_include_file: true }
+
+
+targets:
+  default:
+    filesets:
+      - files_c

--- a/vendor/lowrisc_ip/dv/dpi/uartdpi/uartdpi.h
+++ b/vendor/lowrisc_ip/dv/dpi/uartdpi/uartdpi.h
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_HW_DV_DPI_UARTDPI_UARTDPI_H_
+#define OPENTITAN_HW_DV_DPI_UARTDPI_UARTDPI_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void *uartdpi_create(const char *name, const char *log_file_path);
+void uartdpi_close(void *ctx_void);
+int uartdpi_can_read(void *ctx_void);
+char uartdpi_read(void *ctx_void);
+void uartdpi_write(void *ctx_void, char c);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+#endif  // OPENTITAN_HW_DV_DPI_UARTDPI_UARTDPI_H_

--- a/vendor/lowrisc_ip/dv/dpi/uartdpi/uartdpi.sv
+++ b/vendor/lowrisc_ip/dv/dpi/uartdpi/uartdpi.sv
@@ -1,0 +1,144 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module uartdpi #(
+  parameter integer BAUD = 'x,
+  parameter integer FREQ = 'x,
+  parameter string NAME = "uart0"
+)(
+  input  logic clk_i,
+  input  logic rst_ni,
+  input  bit   active,
+
+  output logic tx_o,
+  input  logic rx_i
+);
+  // Path to a log file. Used if none is specified through the `UARTDPI_LOG_<name>` plusarg.
+  localparam string DEFAULT_LOG_FILE = {NAME, ".log"};
+
+  // Min cycles is 2 for fast test mode
+  localparam int CYCLES_PER_SYMBOL = FREQ / BAUD;
+
+  import "DPI-C" function
+    chandle uartdpi_create(input string name, input string log_file_path);
+
+  import "DPI-C" function
+    void uartdpi_close(input chandle ctx);
+
+  import "DPI-C" function
+    byte uartdpi_read(input chandle ctx);
+
+  import "DPI-C" function
+    int uartdpi_can_read(input chandle ctx);
+
+  import "DPI-C" function
+    void uartdpi_write(input chandle ctx, int data);
+
+  chandle ctx;
+  string log_file_path = DEFAULT_LOG_FILE;
+
+  function automatic void initialize();
+    $value$plusargs({"UARTDPI_LOG_", NAME, "=%s"}, log_file_path);
+    ctx = uartdpi_create(NAME, log_file_path);
+  endfunction
+
+  initial begin
+    if (active) initialize();
+  end
+
+  always @(posedge active) begin
+    if (ctx == null) initialize();
+  end
+
+  final begin
+    uartdpi_close(ctx);
+    ctx = null;
+  end
+
+  // TX
+  reg txactive;
+  int  txcount;
+  int  txcyccount;
+  reg [9:0] txsymbol;
+  bit seen_reset;
+
+  logic eff_clk;
+  assign eff_clk = clk_i & active;
+
+  always_ff @(negedge eff_clk or negedge rst_ni) begin
+    if (!rst_ni) begin
+      tx_o <= 1;
+      txactive <= 0;
+    end else begin
+      if (!txactive) begin
+        tx_o <= 1;
+        if (uartdpi_can_read(ctx)) begin
+          automatic int c = uartdpi_read(ctx);
+          txsymbol <= {1'b1, c[7:0], 1'b0};
+          txactive <= 1;
+          txcount <= 0;
+          txcyccount <= 0;
+        end
+      end else begin
+        txcyccount <= txcyccount + 1;
+        tx_o <= txsymbol[txcount];
+        if (txcyccount == CYCLES_PER_SYMBOL - 1) begin
+          txcyccount <= 0;
+          if (txcount == 9)
+            txactive <= 0;
+          else
+            txcount <= txcount + 1;
+        end
+      end
+    end
+  end
+
+  // RX
+  reg rxactive;
+  int rxcount;
+  int rxcyccount;
+  reg [7:0] rxsymbol;
+
+  always_ff @(negedge eff_clk or negedge rst_ni) begin
+    rxcyccount <= rxcyccount + 1;
+
+    if (!rst_ni) begin
+      rxactive <= 0;
+      seen_reset <= 1;
+    end else begin
+      if (!rxactive) begin
+        if (!rx_i && seen_reset) begin
+          rxactive <= 1;
+          rxcount <= 0;
+          rxcyccount <= 0;
+        end
+      end else begin
+        if (rxcount == 0) begin
+          if (rxcyccount == CYCLES_PER_SYMBOL/2 - 1) begin
+            if (rx_i) begin
+              rxactive <= 0;
+            end else begin
+              rxcount <= rxcount + 1;
+              rxcyccount <= 0;
+            end
+          end
+        end else if (rxcount <= 8) begin
+          if (rxcyccount == CYCLES_PER_SYMBOL - 1) begin
+            rxsymbol[rxcount-1] <= rx_i;
+            rxcount <= rxcount + 1;
+            rxcyccount <= 0;
+          end
+        end else begin
+          if (rxcyccount == CYCLES_PER_SYMBOL - 1) begin
+            rxactive <= 0;
+            if (rx_i) begin
+              uartdpi_write(ctx, rxsymbol);
+            end
+          end
+        end
+      end
+    end
+  end
+
+endmodule

--- a/vendor/lowrisc_ip/dv/dpi/uartdpi/uartdpi_sv.core
+++ b/vendor/lowrisc_ip/dv/dpi/uartdpi/uartdpi_sv.core
@@ -1,0 +1,17 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv_dpi_sv:uartdpi:0.1"
+description: "UART-DPI SV code"
+
+filesets:
+  files_rtl:
+    files:
+      - uartdpi.sv: { file_type: systemVerilogSource }
+
+
+targets:
+  default:
+    filesets:
+      - files_rtl


### PR DESCRIPTION
Draft because it's currently sitting atop https://github.com/lowRISC/ibex-demo-system/pull/91

Recommend making the following change when testing:

```diff
diff --git a/sw/c/demo/hello_world/main.c b/sw/c/demo/hello_world/main.c
index 3d4b333..0ef4b4a 100644
--- a/sw/c/demo/hello_world/main.c
+++ b/sw/c/demo/hello_world/main.c
@@ -29,7 +29,7 @@ int main(void) {
 
   // This indicates how often the timer gets updated.
   timer_init();
-  timer_enable(5000000);
+  timer_enable(500);
 
   uint64_t last_elapsed_time = get_elapsed_time();
```