### PR TITLE
Sonata v0.5 board changes

### DIFF
--- a/data/pins_sonata.xdc
+++ b/data/pins_sonata.xdc
@@ -7,7 +7,7 @@ create_clock -period 40.000 -name main_clk -waveform {0.000 20.000} [get_ports m
 create_clock -period 100.000 -name tck_i -waveform {0.000 50.000} [get_ports tck_i]
 
 ## Reset
-set_property -dict { PACKAGE_PIN R11 IOSTANDARD LVCMOS33 } [get_ports {nrst_btn}]
+set_property -dict { PACKAGE_PIN T5 IOSTANDARD LVCMOS33 } [get_ports {nrst_btn}]
 
 ## General purpose LEDs
 set_property -dict { PACKAGE_PIN B13 IOSTANDARD LVCMOS33 } [get_ports {led_user[0]}];

--- a/data/pins_sonata.xdc
+++ b/data/pins_sonata.xdc
@@ -3,12 +3,11 @@
 ## SPDX-License-Identifier: Apache-2.0
 
 ## Clocks
-create_clock -period 40.000 -name mainclk -waveform {0.000 20.000} [get_ports main_clk]
-create_clock -period 100.000 -name tck -waveform {0.000 50.000} [get_ports tck_i]
+create_clock -period 40.000 -name main_clk -waveform {0.000 20.000} [get_ports main_clk]
+create_clock -period 100.000 -name tck_i -waveform {0.000 50.000} [get_ports tck_i]
 
 ## Reset
-set_property PACKAGE_PIN R11 [get_ports {nrst_btn}]
-set_property IOSTANDARD LVCMOS33 [get_ports {nrst_btn}]
+set_property -dict { PACKAGE_PIN R11 IOSTANDARD LVCMOS33 } [get_ports {nrst_btn}]
 
 ## General purpose LEDs
 set_property -dict { PACKAGE_PIN B13 IOSTANDARD LVCMOS33 } [get_ports {led_user[0]}];


### PR DESCRIPTION
This PR changes the pin of the reset button for the correct one of the V0.5 board.

This PR also contains some minor changes:
- Align the names of the clocks with the port names.
- Use dictionary for the reset button.
