### PR TITLE
Fix Verilator build and lint

### DIFF
--- a/dv/verilator/demo_system_verilator_lint.vlt
+++ b/dv/verilator/demo_system_verilator_lint.vlt
@@ -25,4 +25,7 @@ lint_off -rule PINMISSING -file "*pulp_riscv_dbg*"
 lint_off -rule UNUSED -file "*ibex_register_file_fpga*"
 
 lint_off -rule UNOPTFLAT -file "*/lowrisc_prim_fifo_0/rtl/prim_fifo_async_simple.sv"
-lint_off -rule WIDTHEXPAND -file "*pulp_riscv_dbg/src/dm_mem.sv"
+lint_off -rule WIDTH -file "*pulp_riscv_dbg/src/dm_mem.sv"
+
+lint_off -rule UNDRIVEN -file "*ibex_register_file_fpga.sv"
+lint_off -rule IMPERFECTSCH -file "*prim_flop_2sync.sv"

--- a/ibex_demo_system_core.core
+++ b/ibex_demo_system_core.core
@@ -22,12 +22,7 @@ filesets:
       - rtl/system/spi_top.sv
     file_type: systemVerilogSource
 
-  files_lint_verilator:
-    files:
-      - lint/verilator_waiver.vlt: {file_type: vlt}
-
 targets:
   default:
     filesets:
-      - tool_verilator ? (files_lint_verilator)
       - files_rtl_demo_system


### PR DESCRIPTION
- WIDTHEXPAND does not exist for Verilator 4.210
- The verilator waiver file does not exist
- Added some extra lint waivers