### PR TITLE
Update ibex_demo_system.core

### DIFF
--- a/ibex_demo_system.core
+++ b/ibex_demo_system.core
@@ -178,7 +178,7 @@ targets:
           - '--trace-structs'
           - '--trace-params'
           - '--trace-max-array 1024'
-          - '-CFLAGS "-std=c++11 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=top_verilator"'
+          - '-CFLAGS "-std=c++14 -Wall -DVM_TRACE_FMT_FST -DTOPLEVEL_NAME=top_verilator"'
           - '-LDFLAGS "-pthread -lutil -lelf"'
           - "-Wall"
           - "-Wwarn-IMPERFECTSCH"


### PR DESCRIPTION
Fix for Verilator 5.x

# Output from sample `hello_world` 
```bash
./build/lowrisc_ibex_demo_system_0/sim-verilator/Vtop_verilator \
  --meminit=ram,./sw/c/build/demo/hello_world/demo
Simulation of Ibex Demo System
==============================

Tracing can be toggled by sending SIGUSR1 to this process:
$ kill -USR1 421326

UART: Created /dev/pts/3 for uart0. Connect to it with any terminal program, e.g.
$ screen /dev/pts/3
UART: Additionally writing all UART output to 'uart0.log'.

Simulation running, end by pressing CTRL-c.
^CReceived stop request, shutting down simulation.

Simulation statistics
=====================
Executed cycles:  57408461
Wallclock time:   39.825 s
Simulation speed: 1.44152e+06 cycles/s (1441.52 kHz)

Performance Counters
====================
Cycles:                     69899
Instructions Retired:       39498
LSU Busy:                   17890
Fetch Wait:                 2982
Loads:                      10981
Stores:                     6909
Jumps:                      3367
Conditional Branches:       2395
Taken Conditional Branches: 1258
```