### PR TITLE
Set objcopy to RISC-V

### DIFF
--- a/sw/c/gcc_toolchain.cmake
+++ b/sw/c/gcc_toolchain.cmake
@@ -1,6 +1,7 @@
 set(LINKER_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/../common/link.ld")
 set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_C_COMPILER riscv32-unknown-elf-gcc)
+set(CMAKE_OBJCOPY riscv32-unknown-elf-objcopy)
 set(CMAKE_C_FLAGS_INIT
     "-march=rv32imc -mabi=ilp32 -mcmodel=medany -Wall -fvisibility=hidden -ffreestanding")
 set(CMAKE_ASM_FLAGS_INIT "-march=rv32imc")


### PR DESCRIPTION
Before this some build environments would use an objcopy that was not RISC-V compliant.

Closes: https://github.com/lowRISC/ibex-demo-system/issues/78