### PR TITLE
Add packaging to python requirements

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -8,6 +8,7 @@ hjson
 mako
 pyyaml
 wheel
+packaging
 
 # Development version of edalize until all our changes are upstream
 git+https://github.com/lowRISC/edalize.git@ot


### PR DESCRIPTION
The packaging requirement is needed to run `util/check_tool_requirements.py` in the virtual environment.