### PR TITLE
Enable ratified bitmanip extensions for Rust demos

### DIFF
--- a/sw/rust/.cargo/config.toml
+++ b/sw/rust/.cargo/config.toml
@@ -5,6 +5,9 @@
 [build]
 target = "riscv32imc-unknown-none-elf"
 
+# Enable supported bitmanip extension features.
+rustflags = ["-Ctarget-feature=+zba,+zbb,+zbc,+zbs"]
+
 [target.riscv32imc-unknown-none-elf]
 runner = "../../util/load_demo_system.sh run"
 

--- a/sw/rust/rust-toolchain.toml
+++ b/sw/rust/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 targets = ["riscv32imc-unknown-none-elf"]
+channel = "nightly"

--- a/sw/rust/rust-toolchain.toml
+++ b/sw/rust/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-targets = ["riscv32imc-unknown-none-elf"]
 channel = "nightly"
+components = ["rust-src"]


### PR DESCRIPTION
I don't think bitmanip is important for the demos, just thought it was interesting that you can enable them.

Happy if this doesn't get merged, but someone can use this as a reference if they need it elsewhere.