### PR TITLE
Fix uninitialized signal error 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ probe is required.
 * openocd (version 0.11.0 or above)
 * screen
 * srecord
+* verilator (version 5.024-1 or above)
 
 ## Container Guide
 

--- a/vendor/lowrisc_ibex/dv/verilator/pcount/cpp/ibex_pcounts.cc
+++ b/vendor/lowrisc_ibex/dv/verilator/pcount/cpp/ibex_pcounts.cc
@@ -53,7 +53,7 @@ static bool has_hpm_counter(int index) {
 
 std::string ibex_pcount_string(bool csv) {
   char separator = csv ? ',' : ':';
-  std::string::size_type longest_name_length;
+  std::string::size_type longest_name_length = 0;
 
   if (!csv) {
     longest_name_length = 0;


### PR DESCRIPTION
I had some issues when building the core for simulation using verilator (see #125) This was first related to me using an older version of verilator as well as an uninitialized warning I was getting from verilator. 

This PR documents adds verilator as a dependency and specifies the version and also initializes the variable that was causing the issue.

Closes: #125 