### PR TITLE
Update openocd commands to flash software

### DIFF
--- a/util/arty-a7-openocd-cfg.tcl
+++ b/util/arty-a7-openocd-cfg.tcl
@@ -30,7 +30,7 @@ riscv set_ir dmi 0x23
 
 adapter speed 10000
 
-riscv set_prefer_sba on
+riscv set_mem_access sysbus
 gdb_report_data_abort enable
 gdb_report_register_access_error enable
 gdb_breakpoint_override hard

--- a/util/sonata-openocd-cfg.tcl
+++ b/util/sonata-openocd-cfg.tcl
@@ -22,7 +22,7 @@ target create $_TARGETNAME riscv -chain-position $_TARGETNAME
 
 adapter speed 10000
 
-riscv set_prefer_sba on
+riscv set_mem_access sysbus
 gdb_report_data_abort enable
 gdb_report_register_access_error enable
 gdb_breakpoint_override hard


### PR DESCRIPTION
riscv set_prefer_sba command to use System Bus Access to access memory deprecated. 
Update use of riscv set_mem_access instead.

Updated cmds "riscv set_prefer_sba" and "riscv set_mem_access" in openocd configuration file used to flash software.