### PR TITLE
Change logic behind JTAG tap selection to make instrustions work for the demo platform

### DIFF
--- a/ibex_demo_system.core
+++ b/ibex_demo_system.core
@@ -166,8 +166,6 @@ targets:
     parameters:
       - SRAMInitFile
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx
-    flags:
-      use_bscane_tap: true
   synth_cw305:
     <<: *default_target
     default_tool: vivado
@@ -182,8 +180,6 @@ targets:
     parameters:
       - SRAMInitFile
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx
-    flags:
-      use_bscane_tap: true
   synth_cw312a35:
     <<: *default_target
     default_tool: vivado
@@ -197,8 +193,6 @@ targets:
     parameters:
       - SRAMInitFile
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx
-    flags:
-      use_bscane_tap: true
   synth_blackboard:
     <<: *default_target
     default_tool: vivado
@@ -212,8 +206,6 @@ targets:
     parameters:
       - SRAMInitFile
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx
-    flags:
-      use_bscane_tap: true
   synth_boolean:
     <<: *default_target
     default_tool: vivado
@@ -227,8 +219,6 @@ targets:
     parameters:
       - SRAMInitFile
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx
-    flags:
-      use_bscane_tap: true
   synth_nexysa7:
     <<: *default_target
     default_tool: vivado
@@ -242,8 +232,6 @@ targets:
     parameters:
       - SRAMInitFile
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx
-    flags:
-      use_bscane_tap: true
   synth_artys7-25:
     <<: *default_target
     default_tool: vivado
@@ -257,8 +245,6 @@ targets:
     parameters:
       - SRAMInitFile
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx
-    flags:
-      use_bscane_tap: true
   synth_artys7-50:
     <<: *default_target
     default_tool: vivado
@@ -272,8 +258,6 @@ targets:
     parameters:
       - SRAMInitFile
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplXilinx
-    flags:
-      use_bscane_tap: true
   synth_sonata:
     <<: *default_target
     default_tool: vivado

--- a/pulp_riscv_dbg.core
+++ b/pulp_riscv_dbg.core
@@ -42,5 +42,13 @@ targets:
     filesets:
       - files_src
       - tool_verilator ? (files_verilator)
-      - "use_bscane_tap ? (files_xilinx_bscane_tap)"
-      - "!use_bscane_tap ? (files_jtag_tap)"
+      - target_synth ? (files_xilinx_bscane_tap)
+      - target_synth_cw305 ? (files_xilinx_bscane_tap)
+      - target_synth_cw312a35 ? (files_xilinx_bscane_tap)
+      - target_synth_blackboard ? (files_xilinx_bscane_tap)
+      - target_synth_boolean ? (files_xilinx_bscane_tap)
+      - target_synth_nexyxa7 ? (files_xilinx_bscane_tap)
+      - target_synth_artys7-25 ? (files_xilinx_bscane_tap)
+      - target_synth_artys7-50 ? (files_xilinx_bscane_tap)
+      - target_synth_sonata ? (files_jtag_tap)
+      - tool_verilator ? (files_jtag_tap)


### PR DESCRIPTION
The current instructions fail to work for the demo platform when used with the native Python environment as noted in #116 as the upstream version of FuseSoC does not support tags.

This PR flips the logic surrounding the tags so that the Bscane tap is used by default as this is what is needed for most FPGA-based platforms. Sonata is the obvious exception, so a note has been added to the README.

I've based this off of #136 as that is already approved for merge.