### PR TITLE
[build] Nexys target fix

### DIFF
--- a/pulp_riscv_dbg.core
+++ b/pulp_riscv_dbg.core
@@ -47,7 +47,7 @@ targets:
       - target_synth_cw312a35 ? (files_xilinx_bscane_tap)
       - target_synth_blackboard ? (files_xilinx_bscane_tap)
       - target_synth_boolean ? (files_xilinx_bscane_tap)
-      - target_synth_nexyxa7 ? (files_xilinx_bscane_tap)
+      - target_synth_nexysa7 ? (files_xilinx_bscane_tap)
       - target_synth_artys7-25 ? (files_xilinx_bscane_tap)
       - target_synth_artys7-50 ? (files_xilinx_bscane_tap)
       - target_synth_sonata ? (files_jtag_tap)


### PR DESCRIPTION
Fix the nexysa7 target in pul_riscv_db.core

Thanks to Pontus Andrén for reporting this issue

Close: https://github.com/lowRISC/ibex-demo-system/issues/144