### PR TITLE
Disable bit manipulation features in Rust examples

### DIFF
--- a/sw/rust/.cargo/config.toml
+++ b/sw/rust/.cargo/config.toml
@@ -5,9 +5,6 @@
 [build]
 target = "riscv32imc-unknown-none-elf"
 
-# Enable supported bitmanip extension features.
-rustflags = ["-Ctarget-feature=+zba,+zbb,+zbc,+zbs"]
-
 [target.riscv32imc-unknown-none-elf]
 runner = "../../util/load_demo_system.sh run"
 


### PR DESCRIPTION
As mentionned in #143, the Rust examples currently enable the bit manipulation extensions in the compiler target features. However the Ibex demo system disables the bit manipulation extension in the CPU.

This PR disables the bit manipulation features in the Cargo configuration.

Closes #143.